### PR TITLE
Change Job ID support to use Strings instead of Long, allowing UUIDs

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/rundeck/RundeckJobProjectLinkerAction.java
+++ b/src/main/java/org/jenkinsci/plugins/rundeck/RundeckJobProjectLinkerAction.java
@@ -28,7 +28,7 @@ public class RundeckJobProjectLinkerAction implements Action {
      * @param rundeckJobId ID of the RunDeck job
      * @throws RundeckApiException in case of error while load the job details from RunDeck API
      */
-    public RundeckJobProjectLinkerAction(RundeckInstance rundeck, Long rundeckJobId) throws RundeckApiException {
+    public RundeckJobProjectLinkerAction(RundeckInstance rundeck, String rundeckJobId) throws RundeckApiException {
         this.rundeck = rundeck;
         this.rundeckJob = rundeck.getJob(rundeckJobId);
         this.rundeckJobUrl = buildRundeckJobUrl();

--- a/src/main/java/org/jenkinsci/plugins/rundeck/RundeckNotifier.java
+++ b/src/main/java/org/jenkinsci/plugins/rundeck/RundeckNotifier.java
@@ -42,7 +42,7 @@ import org.kohsuke.stapler.StaplerRequest;
  */
 public class RundeckNotifier extends Notifier {
 
-    private final Long jobId;
+    private final String jobId;
 
     private final String options;
 
@@ -53,7 +53,7 @@ public class RundeckNotifier extends Notifier {
     private final Boolean shouldFailTheBuild;
 
     @DataBoundConstructor
-    public RundeckNotifier(Long jobId, String options, String tag, Boolean shouldWaitForRundeckJob,
+    public RundeckNotifier(String jobId, String options, String tag, Boolean shouldWaitForRundeckJob,
             Boolean shouldFailTheBuild) {
         this.jobId = jobId;
         this.options = options;
@@ -240,7 +240,7 @@ public class RundeckNotifier extends Notifier {
         return BuildStepMonitor.NONE;
     }
 
-    public Long getJobId() {
+    public String getJobId() {
         return jobId;
     }
 
@@ -287,7 +287,7 @@ public class RundeckNotifier extends Notifier {
 
         @Override
         public Publisher newInstance(StaplerRequest req, JSONObject formData) throws FormException {
-            return new RundeckNotifier(formData.getLong("jobId"),
+            return new RundeckNotifier(formData.getString("jobId"),
                                        formData.getString("options"),
                                        formData.getString("tag"),
                                        formData.getBoolean("shouldWaitForRundeckJob"),
@@ -310,7 +310,7 @@ public class RundeckNotifier extends Notifier {
             return FormValidation.ok("Your RunDeck instance is alive, and your credentials are valid !");
         }
 
-        public FormValidation doCheckJob(@QueryParameter("jobId") final Long jobId) {
+        public FormValidation doCheckJob(@QueryParameter("jobId") final String jobId) {
             try {
                 RundeckJob job = rundeckInstance.getJob(jobId);
                 return FormValidation.ok("Your RunDeck job is : %s (project: %s)", job.getFullName(), job.getProject());

--- a/src/main/java/org/jenkinsci/plugins/rundeck/domain/RundeckInstance.java
+++ b/src/main/java/org/jenkinsci/plugins/rundeck/domain/RundeckInstance.java
@@ -99,13 +99,13 @@ public class RundeckInstance implements Serializable {
 
     /**
      * Get the details of a job, identified by the given id.
-     * 
+     *
      * @param jobId - mandatory
      * @return a {@link RundeckJob} instance (won't be null), with details on the job
      * @throws RundeckApiException in case of error calling the API
      * @throws RundeckApiLoginException if the login failed
      */
-    public RundeckJob getJob(Long jobId) throws RundeckApiException, RundeckApiLoginException {
+    public RundeckJob getJob(String jobId) throws RundeckApiException, RundeckApiLoginException {
         if (jobId == null) {
             throw new IllegalArgumentException("jobId is mandatory to get the details of a job !");
         }
@@ -193,7 +193,7 @@ public class RundeckInstance implements Serializable {
 
     /**
      * Run a job, identified by the given id.
-     * 
+     *
      * @param jobId - mandatory
      * @param options for the job, optional
      * @return a {@link RundeckExecution} instance (won't be null), with details on the execution
@@ -201,7 +201,7 @@ public class RundeckInstance implements Serializable {
      * @throws RundeckApiJobRunException if the run failed
      * @throws RundeckApiException in case of error calling the API
      */
-    public RundeckExecution runJob(Long jobId, Properties options) throws RundeckApiException,
+    public RundeckExecution runJob(String jobId, Properties options) throws RundeckApiException,
             RundeckApiLoginException, RundeckApiJobRunException {
         if (jobId == null) {
             throw new IllegalArgumentException("jobId is mandatory to run a job !");

--- a/src/main/java/org/jenkinsci/plugins/rundeck/domain/RundeckJob.java
+++ b/src/main/java/org/jenkinsci/plugins/rundeck/domain/RundeckJob.java
@@ -12,7 +12,7 @@ public class RundeckJob implements Serializable {
 
     private static final long serialVersionUID = 1L;
 
-    private Long id;
+    private String id;
 
     private String name;
 
@@ -34,11 +34,11 @@ public class RundeckJob implements Serializable {
         return fullName.toString();
     }
 
-    public Long getId() {
+    public String getId() {
         return id;
     }
 
-    public void setId(Long id) {
+    public void setId(String id) {
         this.id = id;
     }
 

--- a/src/main/java/org/jenkinsci/plugins/rundeck/domain/RundeckUtils.java
+++ b/src/main/java/org/jenkinsci/plugins/rundeck/domain/RundeckUtils.java
@@ -79,7 +79,7 @@ public class RundeckUtils {
         Node jobNode = document.selectSingleNode("joblist/job");
 
         RundeckJob job = new RundeckJob();
-        job.setId(Long.valueOf(jobNode.valueOf("id")));
+        job.setId(jobNode.valueOf("id"));
         job.setName(jobNode.valueOf("name"));
         job.setDescription(jobNode.valueOf("description"));
         job.setGroup(jobNode.valueOf("group"));
@@ -130,7 +130,7 @@ public class RundeckUtils {
         Node jobNode = execNode.selectSingleNode("job");
         if (jobNode != null) {
             RundeckJob job = new RundeckJob();
-            job.setId(Long.valueOf(jobNode.valueOf("@id")));
+            job.setId(jobNode.valueOf("@id"));
             job.setName(jobNode.valueOf("name"));
             job.setGroup(StringUtils.trimToNull(jobNode.valueOf("group")));
             job.setProject(jobNode.valueOf("project"));

--- a/src/test/java/org/jenkinsci/plugins/rundeck/RundeckNotifierTest.java
+++ b/src/test/java/org/jenkinsci/plugins/rundeck/RundeckNotifierTest.java
@@ -37,7 +37,7 @@ import org.tmatesoft.svn.core.wc.SVNClientManager;
 public class RundeckNotifierTest extends HudsonTestCase {
 
     public void testCommitWithoutTag() throws Exception {
-        RundeckNotifier notifier = new RundeckNotifier(1L, createOptions(), "", false, false);
+        RundeckNotifier notifier = new RundeckNotifier("1", createOptions(), "", false, false);
         notifier.getDescriptor().setRundeckInstance(new MockRundeckInstance());
 
         FreeStyleProject project = createFreeStyleProject();
@@ -63,7 +63,7 @@ public class RundeckNotifierTest extends HudsonTestCase {
     }
 
     public void testStandardCommitWithTag() throws Exception {
-        RundeckNotifier notifier = new RundeckNotifier(1L, null, "#deploy", false, false);
+        RundeckNotifier notifier = new RundeckNotifier("1", null, "#deploy", false, false);
         notifier.getDescriptor().setRundeckInstance(new MockRundeckInstance());
 
         FreeStyleProject project = createFreeStyleProject();
@@ -87,7 +87,7 @@ public class RundeckNotifierTest extends HudsonTestCase {
     }
 
     public void testDeployCommitWithTagWontBreakTheBuild() throws Exception {
-        RundeckNotifier notifier = new RundeckNotifier(1L, null, "#deploy", false, false);
+        RundeckNotifier notifier = new RundeckNotifier("1", null, "#deploy", false, false);
         notifier.getDescriptor().setRundeckInstance(new MockRundeckInstance());
 
         FreeStyleProject project = createFreeStyleProject();
@@ -113,13 +113,13 @@ public class RundeckNotifierTest extends HudsonTestCase {
     }
 
     public void testDeployCommitWithTagWillBreakTheBuild() throws Exception {
-        RundeckNotifier notifier = new RundeckNotifier(1L, null, "#deploy", false, true);
+        RundeckNotifier notifier = new RundeckNotifier("1", null, "#deploy", false, true);
         notifier.getDescriptor().setRundeckInstance(new MockRundeckInstance() {
 
             private static final long serialVersionUID = 1L;
 
             @Override
-            public RundeckExecution runJob(Long jobId, Properties options) throws RundeckApiException,
+            public RundeckExecution runJob(String jobId, Properties options) throws RundeckApiException,
                     RundeckApiLoginException, RundeckApiJobRunException {
                 throw new RundeckApiJobRunException("Fake error for testing");
             }
@@ -150,13 +150,13 @@ public class RundeckNotifierTest extends HudsonTestCase {
     }
 
     public void testExpandEnvVarsInOptions() throws Exception {
-        RundeckNotifier notifier = new RundeckNotifier(1L, createOptions(), null, false, true);
+        RundeckNotifier notifier = new RundeckNotifier("1", createOptions(), null, false, true);
         notifier.getDescriptor().setRundeckInstance(new MockRundeckInstance() {
 
             private static final long serialVersionUID = 1L;
 
             @Override
-            public RundeckExecution runJob(Long jobId, Properties options) throws RundeckApiException,
+            public RundeckExecution runJob(String jobId, Properties options) throws RundeckApiException,
                     RundeckApiLoginException, RundeckApiJobRunException {
                 Assert.assertEquals(4, options.size());
                 Assert.assertEquals("value 1", options.getProperty("option1"));
@@ -181,7 +181,7 @@ public class RundeckNotifierTest extends HudsonTestCase {
     }
 
     public void testUpstreamBuildWithTag() throws Exception {
-        RundeckNotifier notifier = new RundeckNotifier(1L, null, "#deploy", false, false);
+        RundeckNotifier notifier = new RundeckNotifier("1", null, "#deploy", false, false);
         notifier.getDescriptor().setRundeckInstance(new MockRundeckInstance());
 
         FreeStyleProject upstream = createFreeStyleProject("upstream");
@@ -216,7 +216,7 @@ public class RundeckNotifierTest extends HudsonTestCase {
     }
 
     public void testFailedBuild() throws Exception {
-        RundeckNotifier notifier = new RundeckNotifier(1L, createOptions(), "", false, false);
+        RundeckNotifier notifier = new RundeckNotifier("1", createOptions(), "", false, false);
         notifier.getDescriptor().setRundeckInstance(new MockRundeckInstance());
 
         FreeStyleProject project = createFreeStyleProject();
@@ -240,13 +240,13 @@ public class RundeckNotifierTest extends HudsonTestCase {
     }
 
     public void testWaitForRundeckJob() throws Exception {
-        RundeckNotifier notifier = new RundeckNotifier(1L, createOptions(), "", true, false);
+        RundeckNotifier notifier = new RundeckNotifier("1", createOptions(), "", true, false);
         notifier.getDescriptor().setRundeckInstance(new MockRundeckInstance() {
 
             private static final long serialVersionUID = 1L;
 
             @Override
-            public RundeckExecution runJob(Long jobId, Properties options) throws RundeckApiException,
+            public RundeckExecution runJob(String jobId, Properties options) throws RundeckApiException,
                     RundeckApiLoginException, RundeckApiJobRunException {
                 RundeckExecution execution = new RundeckExecution();
                 execution.setStatus(ExecutionStatus.SUCCEEDED);
@@ -349,7 +349,7 @@ public class RundeckNotifierTest extends HudsonTestCase {
         }
 
         @Override
-        public RundeckExecution runJob(Long jobId, Properties options) throws RundeckApiException,
+        public RundeckExecution runJob(String jobId, Properties options) throws RundeckApiException,
                 RundeckApiLoginException, RundeckApiJobRunException {
             RundeckExecution execution = new RundeckExecution();
             execution.setStatus(ExecutionStatus.RUNNING);
@@ -364,7 +364,7 @@ public class RundeckNotifierTest extends HudsonTestCase {
         }
 
         @Override
-        public RundeckJob getJob(Long jobId) throws RundeckApiException, RundeckApiLoginException {
+        public RundeckJob getJob(String jobId) throws RundeckApiException, RundeckApiLoginException {
             RundeckJob job = new RundeckJob();
             return job;
         }

--- a/src/test/java/org/jenkinsci/plugins/rundeck/domain/RundeckInstanceTest.java
+++ b/src/test/java/org/jenkinsci/plugins/rundeck/domain/RundeckInstanceTest.java
@@ -25,7 +25,7 @@ public class RundeckInstanceTest extends TestCase {
         rundeck = new RundeckInstance(rundeck.getUrl(), "invalid", "invalidToo");
         if (rundeck.isAlive()) {
             try {
-                rundeck.runJob(1L, null);
+                rundeck.runJob("1", null);
                 fail("login for an invalid user should have failed !");
             } catch (RundeckApiLoginException e) {
                 assertNull("Login failure for invalid user should not have a cause ! cause : " + e.getCause(),
@@ -39,7 +39,7 @@ public class RundeckInstanceTest extends TestCase {
     public void testInvalidJob() throws Exception {
         if (rundeck.isAlive()) {
             try {
-                rundeck.runJob(4242424242L, null);
+                rundeck.runJob("4242424242", null);
                 fail("running an invalid job should have failed !");
             } catch (RundeckApiJobRunException e) {
                 assertNull("failure when running an invalid job should not have a cause ! cause : " + e.getCause(),
@@ -55,7 +55,7 @@ public class RundeckInstanceTest extends TestCase {
             Properties options = new Properties();
             options.setProperty("command", "ls");
             options.setProperty("dir", "/tmp");
-            RundeckExecution execution = rundeck.runJob(1l, options);
+            RundeckExecution execution = rundeck.runJob("1", options);
             assertEquals(rundeck.getLogin(), execution.getStartedBy());
         } else {
             System.out.println("No live RunDeck instance at " + rundeck.getUrl() + " - doing nothing...");

--- a/src/test/java/org/jenkinsci/plugins/rundeck/domain/RundeckUtilsTest.java
+++ b/src/test/java/org/jenkinsci/plugins/rundeck/domain/RundeckUtilsTest.java
@@ -32,7 +32,7 @@ public class RundeckUtilsTest extends TestCase {
         InputStream input = getClass().getResourceAsStream("job-definition.xml");
         RundeckJob job = RundeckUtils.parseJobDefinition(input);
 
-        assertEquals(new Long(1), job.getId());
+        assertEquals("1", job.getId());
         assertEquals("job-name", job.getName());
         assertEquals("job description", job.getDescription());
         assertEquals("group-name", job.getGroup());
@@ -64,7 +64,7 @@ public class RundeckUtilsTest extends TestCase {
         assertEquals(null, execution.getEndedAt());
         assertEquals("ls ${option.dir}", execution.getDescription());
 
-        assertEquals(new Long(1), job.getId());
+        assertEquals("1", job.getId());
         assertEquals("ls", job.getName());
         assertEquals("test", job.getGroup());
         assertEquals("test", job.getProject());


### PR DESCRIPTION
The latest rundeck 1.3 beta now uses UUIDs by default, which are not parseable as Longs.  This patch updates the rundeck-plugin to use Strings in place of Longs.
