### PR TITLE
Build the url using the getRootUrl method

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/rundeck/OptionProvider.java
+++ b/src/main/java/org/jenkinsci/plugins/rundeck/OptionProvider.java
@@ -239,7 +239,7 @@ public class OptionProvider {
      */
     private String buildArtifactUrl(Run<?, ?> build, Artifact artifact) {
         StringBuilder url = new StringBuilder();
-        url.append(Hudson.getInstance().getRootUrlFromRequest());
+        url.append(Hudson.getInstance().getRootUrl());
         url.append(build.getUrl()).append("artifact/").append(artifact.getHref());
         return url.toString();
     }


### PR DESCRIPTION
This PR solves an issue where the plugin ignores the configured root URL and instead uses localhost:8080.

For more information, see https://groups.google.com/forum/#!topic/rundeck-discuss/va-Ll0SxOXE
