### PR TITLE
Fix for Exception when using $ARTIFACT_NAME

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/rundeck/RundeckNotifier.java
+++ b/src/main/java/org/jenkinsci/plugins/rundeck/RundeckNotifier.java
@@ -242,7 +242,7 @@ public class RundeckNotifier extends Notifier {
         // http://groups.google.com/group/rundeck-discuss/browse_thread/thread/94a6833b84fdc10b
         Matcher matcher = TOKEN_ARTIFACT_NAME_PATTERN.matcher(input);
         int idx = 0;
-        while (matcher.find(idx)) {
+        while (matcher.reset(input).find(idx)) {
             idx = matcher.end();
             String regex = matcher.group(1);
             Pattern pattern = Pattern.compile(regex);


### PR DESCRIPTION
Pushing pull request:
https://github.com/jhmartin/jenkins-rundeck-plugin/commit/6aed3bb97aa2c1136a65fbc6446d980509e71f09
against upstream.  Without this fix $ARTIFACT_NAME{regex} will throw an exception if regex matches.
