### PR TITLE
Badge icons fail is jenkins is not root as "/"

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/rundeck/RundeckNotifier/RundeckExecutionBuildBadgeAction/badge.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/rundeck/RundeckNotifier/RundeckExecutionBuildBadgeAction/badge.jelly
@@ -1,3 +1,3 @@
 <a href="${it.urlName}" title="${it.displayName}">
-  <img width="16" height="16" title="${it.displayName}" src="${it.iconFileName}"/>
+  <img width="16" height="16" title="${it.displayName}" src="${rootURL}${it.iconFileName}"/>
 </a>


### PR DESCRIPTION
- Adds ${rootURL} as a prefix to the badge iconFileName.
