### PR TITLE
[JENKINS-28697] Aborted build is marked as FAILED

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@
 .settings
 target
 work
+
+*.iml
+.idea/


### PR DESCRIPTION
Should fix treating aborted build as SUCCESS ([JENKINS-28697](https://issues.jenkins-ci.org/browse/JENKINS-28697)). In addition on a build abort there is a try to abort also Rundeck job.

There are some other cases (like aborting a build not while sleeping) which could be better covered, but I don't know Jenkins API good enough.

Unfortunately the new feature has no tests, but I had problems forcing the tests infrastructure to simulate an aborted build.