### PR TITLE
Add Log Tailing

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -71,6 +71,13 @@
           <artifactId>commons-lang</artifactId>
           <version>2.6</version>
       </dependency>
+	<dependency>
+		<groupId>org.jmockit</groupId>
+		<artifactId>jmockit</artifactId>
+		<version>1.17</version>
+		<scope>test</scope>
+	</dependency>
+      
   </dependencies>
 
   <!-- get every artifact through repo.jenkins-ci.org, which proxies all the artifacts that we need -->

--- a/src/main/java/org/jenkinsci/plugins/rundeck/RunDeckLogTail.java
+++ b/src/main/java/org/jenkinsci/plugins/rundeck/RunDeckLogTail.java
@@ -122,10 +122,10 @@ public class RunDeckLogTail implements Iterable<List<RundeckOutputEntry>> {
         }
 
         private boolean checkCompletionState(RundeckOutput rundeckOutput) {
-            
+
             boolean outputCompleted = Boolean.TRUE.equals(rundeckOutput.isCompleted());
-            boolean execCompleted =  Boolean.TRUE.equals(rundeckOutput.isExecCompleted());
-            log.log(Level.FINE, "Checking completetion state with outputCompleted [{0}] and execCompleted [{1}]", new Object[] {outputCompleted, execCompleted});
+            boolean execCompleted = Boolean.TRUE.equals(rundeckOutput.isExecCompleted());
+            log.log(Level.FINE, "Checking completetion state with outputCompleted [{0}] and execCompleted [{1}]", new Object[] { outputCompleted, execCompleted });
             return outputCompleted && execCompleted;
         }
 
@@ -140,9 +140,9 @@ public class RunDeckLogTail implements Iterable<List<RundeckOutputEntry>> {
 
         private boolean updateIterationState(RundeckOutput rundeckOutput) {
             int nextOffset = rundeckOutput.getOffset();
-            if (offset != nextOffset){
+            if (offset != nextOffset) {
                 offset = nextOffset;
-                log.log(Level.FINE, "Offset is now set to [{0}]", new Object[] { offset});
+                log.log(Level.FINE, "Offset is now set to [{0}]", new Object[] { offset });
                 return true;
             }
             return false;

--- a/src/main/java/org/jenkinsci/plugins/rundeck/RunDeckLogTail.java
+++ b/src/main/java/org/jenkinsci/plugins/rundeck/RunDeckLogTail.java
@@ -28,10 +28,9 @@ public class RunDeckLogTail implements Iterable<List<RundeckOutputEntry>> {
     private final long sleepUnmodified;
     private final long sleepModified;
 
-    
-
     /**
      * Standard constructor that contains sensible defaults for handling the API calls correctly.
+     * 
      * @param rundeckClient
      * @param executionId
      */
@@ -40,14 +39,22 @@ public class RunDeckLogTail implements Iterable<List<RundeckOutputEntry>> {
     }
 
     /**
-     * Extended constructor containing all the variables that can be set. 
-     * @param rundeckClient the runDeckClient
-     * @param executionId the id of the RunDeck job
-     * @param maxlines the maximum number of lines to fetch on each API call
-     * @param maxRetries the maximum number of retry attempts if the api call fails
-     * @param sleepRetry sleep time in ms that will be triggered if a api call fails
-     * @param sleepUnmodified sleep time in ms when the results are unmodified
-     * @param sleepModified sleep time in ms when the results are modified.
+     * Extended constructor containing all the variables that can be set.
+     * 
+     * @param rundeckClient
+     *            the runDeckClient
+     * @param executionId
+     *            the id of the RunDeck job
+     * @param maxlines
+     *            the maximum number of lines to fetch on each API call
+     * @param maxRetries
+     *            the maximum number of retry attempts if the api call fails
+     * @param sleepRetry
+     *            sleep time in ms that will be triggered if a api call fails
+     * @param sleepUnmodified
+     *            sleep time in ms when the results are unmodified
+     * @param sleepModified
+     *            sleep time in ms when the results are modified.
      */
     public RunDeckLogTail(RundeckClient rundeckClient, Long executionId, int maxlines, int maxRetries, long sleepRetry, long sleepUnmodified, long sleepModified) {
         this.rundeckClient = rundeckClient;
@@ -57,7 +64,7 @@ public class RunDeckLogTail implements Iterable<List<RundeckOutputEntry>> {
         this.sleepRetry = sleepRetry;
         this.sleepUnmodified = sleepUnmodified;
         this.sleepModified = sleepModified;
-        
+
     }
 
     public RunDeckLogTailIterator iterator() {
@@ -70,7 +77,7 @@ public class RunDeckLogTail implements Iterable<List<RundeckOutputEntry>> {
         protected long lastmod;
         protected boolean completed;
         protected int retries = 0;
-        
+
         protected List<RundeckOutputEntry> next;
 
         /**
@@ -100,7 +107,8 @@ public class RunDeckLogTail implements Iterable<List<RundeckOutputEntry>> {
                     }
                     retries = 0;
                 } catch (RundeckApiException e) {
-                    log.log(Level.WARNING, "Caught RuntimeException while handling API call for logs. Will retry for max [{0}] times or rethrow exception.", new Object[]{maxRetries, e});
+                    log.log(Level.WARNING, "Caught RuntimeException while handling API call for logs. Will retry for max [{0}] times or rethrow exception.", new Object[] {
+                            maxRetries, e });
                     sleepOrThrowException(e);
                 }
             } catch (InterruptedException e) {
@@ -112,7 +120,7 @@ public class RunDeckLogTail implements Iterable<List<RundeckOutputEntry>> {
 
         private void sleepOrThrowException(RuntimeException e) throws InterruptedException {
             if (retries >= maxRetries) {
-                log.log(Level.SEVERE, "Giving up after [{0}] retries...", new Object[] {maxRetries, e});
+                log.log(Level.SEVERE, "Giving up after [{0}] retries...", new Object[] { maxRetries, e });
                 throw e;
             }
             retries++;
@@ -122,8 +130,8 @@ public class RunDeckLogTail implements Iterable<List<RundeckOutputEntry>> {
         private boolean updateIterationState(RundeckOutput rundeckOutput) {
             offset = rundeckOutput.getOffset();
             lastmod = defaultLong(rundeckOutput.getLastModified(), 0L);
-            boolean c = Boolean.TRUE.equals(rundeckOutput.isCompleted()); 
-            log.log(Level.FINE, "Offset is now set to [{0}], lastmod is now set to [{1}], completed is now set to [{2}]", new Object[] { offset, lastmod,c });
+            boolean c = Boolean.TRUE.equals(rundeckOutput.isCompleted());
+            log.log(Level.FINE, "Offset is now set to [{0}], lastmod is now set to [{1}], completed is now set to [{2}]", new Object[] { offset, lastmod, c });
             return c;
         }
 

--- a/src/main/java/org/jenkinsci/plugins/rundeck/RunDeckLogTail.java
+++ b/src/main/java/org/jenkinsci/plugins/rundeck/RunDeckLogTail.java
@@ -1,0 +1,167 @@
+package org.jenkinsci.plugins.rundeck;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import org.apache.commons.lang.ObjectUtils;
+import org.rundeck.api.RundeckApiException;
+import org.rundeck.api.RundeckClient;
+import org.rundeck.api.RundeckClientBuilder;
+import org.rundeck.api.domain.RundeckOutput;
+import org.rundeck.api.domain.RundeckOutputEntry;
+
+/**
+ * This class implements logtailing for Rundeck.
+ * 
+ * @author ckramer
+ */
+public class RunDeckLogTail implements Iterable<List<RundeckOutputEntry>> {
+
+    private static final Logger log = Logger.getLogger(RunDeckLogTail.class.getName());
+
+    private final RundeckClient rundeckClient;
+    private final Long executionId;
+    private final int maxlines;
+    private final int maxRetries;
+    private final long sleepRetry;
+    private final long sleepUnmodified;
+    private final long sleepModified;
+
+    protected List<RundeckOutputEntry> next;
+
+    /**
+     * Standard constructor that contains sensible defaults for handling the API calls correctly.
+     * @param rundeckClient
+     * @param executionId
+     */
+    public RunDeckLogTail(RundeckClient rundeckClient, Long executionId) {
+        this(rundeckClient, executionId, 50, 5, 15000L, 5000L, 2000L);
+    }
+
+    /**
+     * Extended constructor containing all the variables that can be set. 
+     * @param rundeckClient the runDeckClient
+     * @param executionId the id of the RunDeck job
+     * @param maxlines the maximum number of lines to fetch on each API call
+     * @param maxRetries the maximum number of retry attempts if the api call fails
+     * @param sleepRetry sleep time in ms that will be triggered if a api call fails
+     * @param sleepUnmodified sleep time in ms when the results are unmodified
+     * @param sleepModified sleep time in ms when the results are modified.
+     */
+    public RunDeckLogTail(RundeckClient rundeckClient, Long executionId, int maxlines, int maxRetries, long sleepRetry, long sleepUnmodified, long sleepModified) {
+        this.rundeckClient = rundeckClient;
+        this.executionId = executionId;
+        this.maxlines = maxlines;
+        this.maxRetries = maxRetries;
+        this.sleepRetry = sleepRetry;
+        this.sleepUnmodified = sleepUnmodified;
+        this.sleepModified = sleepModified;
+        next = new ArrayList<RundeckOutputEntry>(maxlines);
+    }
+
+    public RunDeckLogTailIterator iterator() {
+        return new RunDeckLogTailIterator();
+    }
+
+    protected class RunDeckLogTailIterator implements Iterator<List<RundeckOutputEntry>> {
+
+        protected int offset;
+        protected long lastmod;
+        protected boolean completed;
+        protected int retries;
+
+        /**
+         * This will clear and update the result set for the @link {@link #next()} call using the RunDeck Client to perform an API call, it will also update the
+         * offset and last modification date for the next API call. If there are no changes since the last call, this method will sleep for 5 seconds. If there
+         * are changes, it will sleep for 2 seconds so it won't overload the API. Once the API call returns with 'completed' the next call to this method will
+         * return false.</br> If for some reason the sleep is interrupted, the next call to this method will return false.</br>
+         */
+        public boolean hasNext() {
+
+            if (completed) {
+                return false;
+            }
+
+            next.clear();
+            
+            try {
+                try {
+                    log.log(Level.FINE, "Performing API call for executionId [{0}], using offset [{1}] and lastmod [{2}], fetching a maximum of [{3}] lines.", new Object[] {
+                            executionId, offset, lastmod, maxlines });
+                    RundeckOutput rundeckOutput = rundeckClient.getExecutionOutput(executionId, offset, lastmod, maxlines);
+                    updateIterationState(rundeckOutput);
+                    addRunDeckOutputEntriesToResults(rundeckOutput);
+                    if (!completed) {
+                        log.log(Level.INFO, "RunDecks Execution Output is not yet completed. Initializing pause to prevent API hammering");
+                        handleSleep(rundeckOutput.isUnmodified());
+                    }
+                } catch (RundeckApiException e) {
+                    log.log(Level.WARNING, "Caught RuntimeException while handling API call for logs. Will retry for max [{0}] times or rethrow exception.", new Object[]{maxRetries, e});
+                    sleepOrThrowException(e);
+                }
+            } catch (InterruptedException e) {
+                log.warning("Caught InterruptedException, will set completed to 'true'.");
+                completed = true;
+            }
+            return true;
+        }
+
+        private void sleepOrThrowException(RuntimeException e) throws InterruptedException {
+            if (retries >= maxRetries) {
+                log.log(Level.SEVERE, "Giving up after [{0}] retries...", new Object[] {maxRetries, e});
+                throw e;
+            }
+            retries++;
+            Thread.sleep(sleepRetry);
+        }
+
+        private void updateIterationState(RundeckOutput rundeckOutput) {
+            offset = rundeckOutput.getOffset();
+            lastmod = defaultLong(rundeckOutput.getLastModified(), 0L);
+            completed = Boolean.TRUE.equals(rundeckOutput.isCompleted());
+            log.log(Level.FINE, "Offset is now set to [{0}], lastmod is now set to [{1}], completed is now set to [{2}]", new Object[] { offset, lastmod,
+                    completed });
+        }
+
+        private long defaultLong(Long value, long defaultLong) {
+            if (value == null) {
+                return defaultLong;
+            }
+            return value;
+        }
+
+        private void addRunDeckOutputEntriesToResults(RundeckOutput rundeckOutput) {
+
+            List<RundeckOutputEntry> runDeckOutputEntries = rundeckOutput.getLogEntries();
+            if (runDeckOutputEntries != null) {
+                next.addAll(runDeckOutputEntries);
+            }
+        }
+
+        private void handleSleep(boolean unmodified) throws InterruptedException {
+            if (unmodified) {
+                log.log(Level.FINE, "Results are unmodified, sleeping for [{0}] ms.", sleepUnmodified);
+                Thread.sleep(sleepUnmodified);
+            } else {
+                log.log(Level.FINE, "Results are modified, sleeping for [{0}] ms.", sleepModified);
+                Thread.sleep(sleepModified);
+            }
+        }
+
+        /**
+         * Returns the resultset which has been fetched using the hasNext method.
+         */
+        public List<RundeckOutputEntry> next() {
+            return next;
+        }
+
+        public void remove() {
+            throw new UnsupportedOperationException();
+        }
+
+    }
+
+}

--- a/src/main/java/org/jenkinsci/plugins/rundeck/RundeckNotifier.java
+++ b/src/main/java/org/jenkinsci/plugins/rundeck/RundeckNotifier.java
@@ -386,6 +386,10 @@ public class RundeckNotifier extends Notifier {
     public Boolean getIncludeRundeckLogs() {
         return includeRundeckLogs;
     }
+    
+    public Boolean getTailLog() {
+        return tailLog;
+    }
 
     @Override
     public RundeckDescriptor getDescriptor() {

--- a/src/main/java/org/jenkinsci/plugins/rundeck/RundeckNotifier.java
+++ b/src/main/java/org/jenkinsci/plugins/rundeck/RundeckNotifier.java
@@ -4,8 +4,16 @@ import hudson.EnvVars;
 import hudson.Extension;
 import hudson.Launcher;
 import hudson.Util;
-import hudson.model.*;
+import hudson.model.Action;
+import hudson.model.BuildBadgeAction;
+import hudson.model.BuildListener;
+import hudson.model.Result;
+import hudson.model.TopLevelItem;
+import hudson.model.AbstractBuild;
+import hudson.model.AbstractProject;
+import hudson.model.Cause;
 import hudson.model.Cause.UpstreamCause;
+import hudson.model.Hudson;
 import hudson.model.Run.Artifact;
 import hudson.scm.ChangeLogSet.Entry;
 import hudson.tasks.BuildStepDescriptor;
@@ -13,18 +21,25 @@ import hudson.tasks.BuildStepMonitor;
 import hudson.tasks.Notifier;
 import hudson.tasks.Publisher;
 import hudson.util.FormValidation;
+
 import java.io.IOException;
+import java.util.List;
 import java.util.Properties;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-import java.util.List;
+
 import net.sf.json.JSONObject;
+
 import org.apache.commons.lang.StringUtils;
+import org.jenkinsci.plugins.rundeck.RunDeckLogTail.RunDeckLogTailIterator;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.QueryParameter;
 import org.kohsuke.stapler.StaplerRequest;
-import org.rundeck.api.*;
+import org.rundeck.api.RunJobBuilder;
+import org.rundeck.api.RundeckApiException;
 import org.rundeck.api.RundeckApiException.RundeckApiLoginException;
+import org.rundeck.api.RundeckClient;
+import org.rundeck.api.RundeckClientBuilder;
 import org.rundeck.api.domain.RundeckExecution;
 import org.rundeck.api.domain.RundeckExecution.ExecutionStatus;
 import org.rundeck.api.domain.RundeckJob;
@@ -57,15 +72,18 @@ public class RundeckNotifier extends Notifier {
     private final Boolean shouldFailTheBuild;
 
     private final Boolean includeRundeckLogs;
+    
+    private final Boolean tailLog;
+
 
     public RundeckNotifier(String jobId, String options, String nodeFilters, String tag,
             Boolean shouldWaitForRundeckJob, Boolean shouldFailTheBuild) {
-       this(jobId, options, nodeFilters, tag, shouldWaitForRundeckJob, shouldFailTheBuild, false);
+       this(jobId, options, nodeFilters, tag, shouldWaitForRundeckJob, shouldFailTheBuild, false, false);
     }
 
     @DataBoundConstructor
     public RundeckNotifier(String jobId, String options, String nodeFilters, String tag,
-            Boolean shouldWaitForRundeckJob, Boolean shouldFailTheBuild, Boolean includeRundeckLogs) {
+            Boolean shouldWaitForRundeckJob, Boolean shouldFailTheBuild, Boolean includeRundeckLogs, Boolean tailLog) {
         this.jobId = jobId;
         this.options = options;
         this.nodeFilters = nodeFilters;
@@ -73,6 +91,7 @@ public class RundeckNotifier extends Notifier {
         this.shouldWaitForRundeckJob = shouldWaitForRundeckJob;
         this.shouldFailTheBuild = shouldFailTheBuild;
         this.includeRundeckLogs = includeRundeckLogs;
+        this.tailLog = tailLog;
     }
 
     @Override
@@ -188,33 +207,49 @@ public class RundeckNotifier extends Notifier {
 
             if (Boolean.TRUE.equals(shouldWaitForRundeckJob)) {
                 listener.getLogger().println("Waiting for Rundeck execution to finish...");
-                while (ExecutionStatus.RUNNING.equals(execution.getStatus())) {
-                    try {
-                        Thread.sleep(5000);
-                    } catch (InterruptedException e) {
-                        listener.getLogger().println("Oops, interrupted ! " + e.getMessage());
-                        break;
+                if (Boolean.TRUE.equals(includeRundeckLogs) && Boolean.TRUE.equals(tailLog)){
+                    listener.getLogger().println("BEGIN RUNDECK TAILED LOG OUTPUT");
+                    RunDeckLogTail runDeckLogTail = new RunDeckLogTail(rundeck, execution.getId());
+                    RunDeckLogTailIterator runDeckLogTailIterator = runDeckLogTail.iterator();
+                    while(runDeckLogTailIterator.hasNext()){
+                        for (RundeckOutputEntry rundeckOutputEntry : runDeckLogTailIterator.next()) {
+                            listener.getLogger().println(String.format("[%s] [%s] %s", new Object[] {rundeckOutputEntry.getTime(), rundeckOutputEntry.getLevel(), rundeckOutputEntry.getMessage()}));
+                        }
                     }
+                    listener.getLogger().println("END RUNDECK TAILED LOG OUTPUT");
+
                     execution = rundeck.getExecution(execution.getId());
-                }
-                listener.getLogger().println("Rundeck execution #" + execution.getId() + " finished in "
-                        + execution.getDuration() + ", with status : " + execution.getStatus());
+                    logExecutionStatus(listener, execution);
+                } else {
+                    while (ExecutionStatus.RUNNING.equals(execution.getStatus())) {
+                        try {
+                            Thread.sleep(5000);
+                        } catch (InterruptedException e) {
+                            listener.getLogger().println("Oops, interrupted ! " + e.getMessage());
+                            break;
+                        }
+                        execution = rundeck.getExecution(execution.getId());
+                    }
+                    logExecutionStatus(listener, execution);
 
-                if (Boolean.TRUE.equals(includeRundeckLogs)) {
-                   listener.getLogger().println("BEGIN RUNDECK LOG OUTPUT");
-                   RundeckOutput rundeckOutput = rundeck.getJobExecutionOutput(execution.getId(), 0, 0, 0);
-                   if (null != rundeckOutput) {
-                      List<RundeckOutputEntry> logEntries = rundeckOutput.getLogEntries();
-                         if (null != logEntries) {
-                            for (int i=0; i<logEntries.size(); i++) {
-                               RundeckOutputEntry rundeckOutputEntry = (RundeckOutputEntry)logEntries.get(i);
-                               listener.getLogger().println(rundeckOutputEntry.getMessage());
-                            }
-                         }
-                   }
-                   listener.getLogger().println("END RUNDECK LOG OUTPUT");
+                    if (Boolean.TRUE.equals(includeRundeckLogs)) {
+                       listener.getLogger().println("BEGIN RUNDECK LOG OUTPUT");
+                       RundeckOutput rundeckOutput = rundeck.getJobExecutionOutput(execution.getId(), 0, 0, 0);
+                       if (null != rundeckOutput) {
+                          List<RundeckOutputEntry> logEntries = rundeckOutput.getLogEntries();
+                             if (null != logEntries) {
+                                for (int i=0; i<logEntries.size(); i++) {
+                                   RundeckOutputEntry rundeckOutputEntry = (RundeckOutputEntry)logEntries.get(i);
+                                   listener.getLogger().println(rundeckOutputEntry.getMessage());
+                                }
+                             }
+                       }
+                       listener.getLogger().println("END RUNDECK LOG OUTPUT");
+                    }
+    
                 }
-
+                
+                
                 switch (execution.getStatus()) {
                     case SUCCEEDED:
                         return true;
@@ -241,6 +276,11 @@ public class RundeckNotifier extends Notifier {
             listener.getLogger().println("Configuration error : " + e.getMessage());
             return false;
         }
+    }
+
+    private void logExecutionStatus(BuildListener listener, RundeckExecution execution) {
+        listener.getLogger().println("Rundeck execution #" + execution.getId() + " finished in "
+                + execution.getDuration() + ", with status : " + execution.getStatus());
     }
 
     /**
@@ -423,7 +463,8 @@ public class RundeckNotifier extends Notifier {
                                        formData.getString("tag"),
                                        formData.getBoolean("shouldWaitForRundeckJob"),
                                        formData.getBoolean("shouldFailTheBuild"),
-                                       formData.getBoolean("includeRundeckLogs"));
+                                       formData.getBoolean("includeRundeckLogs"), 
+                                       formData.getBoolean("tailLog"));
         }
 
         public FormValidation doTestConnection(@QueryParameter("rundeck.url") final String url,

--- a/src/main/resources/org/jenkinsci/plugins/rundeck/RundeckNotifier/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/rundeck/RundeckNotifier/config.jelly
@@ -17,6 +17,9 @@
   <f:entry title="Include Rundeck job output? (NOTE: requires Wait for Rundeck job to finish)" field="includeRundeckLogs">
     <f:checkbox />
   </f:entry>
+  <f:entry title="Tail Logging? (NOTE: requires Wait for Rundeck job to finish & Include Rundeck job output)" field="tailLog">
+    <f:checkbox />
+  </f:entry>
   <f:entry title="Should fail the build ?" field="shouldFailTheBuild">
     <f:checkbox />
   </f:entry>

--- a/src/main/resources/org/jenkinsci/plugins/rundeck/RundeckNotifier/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/rundeck/RundeckNotifier/config.jelly
@@ -17,7 +17,7 @@
   <f:entry title="Include Rundeck job output? (NOTE: requires Wait for Rundeck job to finish)" field="includeRundeckLogs">
     <f:checkbox />
   </f:entry>
-  <f:entry title="Tail Logging? (NOTE: requires Wait for Rundeck job to finish & Include Rundeck job output)" field="tailLog">
+  <f:entry title="Tail Logging? (NOTE: requires Wait for Rundeck job to finish &amp; Include Rundeck job output)" field="tailLog">
     <f:checkbox />
   </f:entry>
   <f:entry title="Should fail the build ?" field="shouldFailTheBuild">

--- a/src/main/resources/org/jenkinsci/plugins/rundeck/RundeckNotifier/help-shouldWaitForRundeckJob.html
+++ b/src/main/resources/org/jenkinsci/plugins/rundeck/RundeckNotifier/help-shouldWaitForRundeckJob.html
@@ -1,4 +1,6 @@
 <div>
     If checked, then Jenkins builds will wait for Rundeck job executions to finish.
     Otherwise, we will just trigger the execution of a Rundeck job, and move on.
+    Also, if the build does not wait for the RunDeck job, the RunDeck job logging
+    will not be tailed into the Jenkins job log.     
 </div>

--- a/src/main/resources/org/jenkinsci/plugins/rundeck/RundeckNotifier/help-tailLog.html
+++ b/src/main/resources/org/jenkinsci/plugins/rundeck/RundeckNotifier/help-tailLog.html
@@ -1,0 +1,5 @@
+<div>
+    If checked, the RunDeck job logging be tailed into the Jenkins job log.
+    Note that RunDeck job logging is never tailed if <em>Wait for RunDeck job to 
+    finish ?</em> checkbox is not checked.
+</div>

--- a/src/test/java/org/jenkinsci/plugins/rundeck/RunDeckLogTailTest.java
+++ b/src/test/java/org/jenkinsci/plugins/rundeck/RunDeckLogTailTest.java
@@ -103,7 +103,7 @@ public class RunDeckLogTailTest {
             assertEquals("fail!", e.getMessage());
         }
     }
-    
+
     @Test
     public void iteratorIsInterrupted() throws InterruptedException {
         new NonStrictExpectations() {

--- a/src/test/java/org/jenkinsci/plugins/rundeck/RunDeckLogTailTest.java
+++ b/src/test/java/org/jenkinsci/plugins/rundeck/RunDeckLogTailTest.java
@@ -1,0 +1,220 @@
+package org.jenkinsci.plugins.rundeck;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import mockit.Mocked;
+import mockit.NonStrictExpectations;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.rundeck.api.RundeckApiException;
+import org.rundeck.api.RundeckClient;
+import org.rundeck.api.domain.RundeckOutput;
+import org.rundeck.api.domain.RundeckOutputEntry;
+
+public class RunDeckLogTailTest {
+
+    private static final long EXECUTION_ID = 1L;
+
+    @Mocked
+    private RundeckClient rundeckClient;
+
+    @Mocked
+    private RundeckOutput rundeckOutput;
+
+    RunDeckLogTail runDeckLogTail;
+
+    @Before
+    public void before() {
+        long executionId = 1L;
+        int maxLines = 2;
+        int maxRetries = 3;
+        long sleepRetry = 100L;
+        long sleepUnmodified = 100L;
+        long sleepModified = 100L;
+        runDeckLogTail = new RunDeckLogTail(rundeckClient, executionId, maxLines, maxRetries, sleepRetry, sleepUnmodified, sleepModified);
+
+    }
+
+    @Test
+    public void iteratorReturnsResults() {
+
+        new NonStrictExpectations() {
+            {
+                //@formatter:off
+                rundeckClient.getExecutionOutput(EXECUTION_ID, 0, anyLong, 2); result = rundeckOutput;
+                rundeckClient.getExecutionOutput(EXECUTION_ID, 50, 2000L, 2); result = rundeckOutput;
+                rundeckClient.getExecutionOutput(EXECUTION_ID, 100, 3000L, 2); result = rundeckOutput;
+                rundeckOutput.getOffset(); returns(50, 100, 150);
+                rundeckOutput.getLastModified(); returns(1000L, 2000L, 3000L);
+                rundeckOutput.getLogEntries(); returns(createLogEntries(new String[] {"lorem", "ipsum"}), createLogEntries(new String[] {"dolar", "sit"}), createLogEntries(new String[] {"amet"}));;
+                rundeckOutput.isCompleted(); returns (false, false, true);
+                rundeckOutput.isUnmodified(); returns (false, false);
+                //@formatter:on
+            }
+        };
+
+        RunDeckLogTail.RunDeckLogTailIterator iterator = runDeckLogTail.iterator();
+
+        assertTrue(iterator.hasNext());
+        assertMessagesPresentInOrder(iterator.next(), "lorem", "ipsum");
+
+        assertTrue(iterator.hasNext());
+        assertMessagesPresentInOrder(iterator.next(), "dolar", "sit");
+
+        assertTrue(iterator.hasNext());
+        assertMessagesPresentInOrder(iterator.next(), "amet");
+
+        assertFalse(iterator.hasNext());
+
+    }
+
+    @Test
+    public void apiExceptionWillBeCaughtThreeTimesAndThenThrown() throws InterruptedException {
+        new NonStrictExpectations() {
+            {
+                //@formatter:off
+                rundeckClient.getExecutionOutput(EXECUTION_ID, 0, anyLong, 2); result = new RundeckApiException("fail!"); times = 4;
+                //@formatter:on
+            }
+        };
+
+        RunDeckLogTail.RunDeckLogTailIterator iterator = runDeckLogTail.iterator();
+
+        assertTrue(iterator.hasNext());
+        assertMessagesPresentInOrder(iterator.next());
+
+        assertTrue(iterator.hasNext());
+        assertMessagesPresentInOrder(iterator.next());
+
+        assertTrue(iterator.hasNext());
+        assertMessagesPresentInOrder(iterator.next());
+
+        try {
+            iterator.hasNext();
+            fail("Expected exception!");
+        } catch (RundeckApiException e) {
+            assertEquals("fail!", e.getMessage());
+        }
+
+    }
+
+    @Test
+    public void iteratorIsInterrupted() throws InterruptedException {
+        new NonStrictExpectations() {
+
+            @Mocked({ "sleep", "interrupt" })
+            final Thread unused = null;
+            {
+
+                //@formatter:off
+                rundeckClient.getExecutionOutput(EXECUTION_ID, 0, anyLong, 2); result = rundeckOutput;
+                rundeckOutput.getOffset(); returns(50);
+                rundeckOutput.getLastModified(); returns(1000L);
+                rundeckOutput.getLogEntries(); returns(createLogEntries(new String[] {"lorem", "ipsum"}));
+                rundeckOutput.isCompleted(); returns (false);
+                rundeckOutput.isUnmodified(); returns (false);
+                Thread.sleep(anyLong); result= new InterruptedException();
+                onInstance(Thread.currentThread()).interrupt();
+                //@formatter:on
+            }
+        };
+
+        RunDeckLogTail.RunDeckLogTailIterator iterator = runDeckLogTail.iterator();
+
+        assertTrue(iterator.hasNext());
+        assertMessagesPresentInOrder(iterator.next(), "lorem", "ipsum");
+
+        assertFalse(iterator.hasNext());
+    }
+
+    @Test
+    public void autoBoxingIsHandledCorrectly() {
+        new NonStrictExpectations() {
+            {
+                //@formatter:off
+                rundeckClient.getExecutionOutput(EXECUTION_ID, 0, 0L, 2); result = rundeckOutput;
+                rundeckClient.getExecutionOutput(EXECUTION_ID, 0, 0L, 2); result = rundeckOutput;
+                rundeckClient.getExecutionOutput(EXECUTION_ID, 50, 2000L, 2); result = rundeckOutput;
+                rundeckOutput.getOffset(); returns(0, 50, 100);
+                rundeckOutput.getLastModified(); returns(null, 1000L, 2000L);
+                rundeckOutput.getLogEntries(); returns(createLogEntries(new String[] {}), createLogEntries(new String[] {}), createLogEntries(new String[] {"dolar", "sit", "amet"}));;
+                rundeckOutput.isCompleted(); returns (null, false, true);
+                rundeckOutput.isUnmodified(); returns (false, true);
+                //@formatter:on
+            }
+        };
+
+        RunDeckLogTail.RunDeckLogTailIterator iterator = runDeckLogTail.iterator();
+
+        assertTrue(iterator.hasNext());
+        assertMessagesPresentInOrder(iterator.next());
+
+        assertTrue(iterator.hasNext());
+        assertMessagesPresentInOrder(iterator.next());
+
+        assertTrue(iterator.hasNext());
+        assertMessagesPresentInOrder(iterator.next(), "dolar", "sit", "amet");
+
+        assertFalse(iterator.hasNext());
+
+    }
+
+    @Test
+    public void interatorUnmodifiedResultsButNotDone() {
+        new NonStrictExpectations() {
+            {
+                //@formatter:off
+                rundeckClient.getExecutionOutput(EXECUTION_ID, 0, anyLong, 2); result = rundeckOutput;
+                rundeckClient.getExecutionOutput(EXECUTION_ID, 50, 2000L, 2); result = rundeckOutput;
+                rundeckClient.getExecutionOutput(EXECUTION_ID, 50, 2000L, 2); result = rundeckOutput;
+                rundeckOutput.getOffset(); returns(50, 50, 150);
+                rundeckOutput.getLastModified(); returns(1000L, 1000L, 3000L);
+                rundeckOutput.getLogEntries(); returns(createLogEntries(new String[] {"lorem", "ipsum"}), createLogEntries(new String[] {}), createLogEntries(new String[] {"dolar", "sit", "amet"}));;
+                rundeckOutput.isCompleted(); returns (false, false, true);
+                rundeckOutput.isUnmodified(); returns (false, true);
+                //@formatter:on
+            }
+        };
+
+        RunDeckLogTail.RunDeckLogTailIterator iterator = runDeckLogTail.iterator();
+
+        assertTrue(iterator.hasNext());
+        assertMessagesPresentInOrder(iterator.next(), "lorem", "ipsum");
+
+        assertTrue(iterator.hasNext());
+        assertMessagesPresentInOrder(iterator.next());
+
+        assertTrue(iterator.hasNext());
+        assertMessagesPresentInOrder(iterator.next(), "dolar", "sit", "amet");
+
+        assertFalse(iterator.hasNext());
+
+    }
+
+    public void assertMessagesPresentInOrder(List<RundeckOutputEntry> rundeckOutputEntries, String... messages) {
+
+        int i = 0;
+        for (RundeckOutputEntry rundeckOutputEntry : rundeckOutputEntries) {
+            assertEquals(rundeckOutputEntry.getMessage(), messages[i]);
+            i++;
+        }
+    }
+
+    public List<RundeckOutputEntry> createLogEntries(String... messages) {
+        List<RundeckOutputEntry> results = new ArrayList<RundeckOutputEntry>();
+        for (String message : messages) {
+            RundeckOutputEntry rundeckOutputEntry = new RundeckOutputEntry();
+            rundeckOutputEntry.setMessage(message);
+            results.add(rundeckOutputEntry);
+        }
+        return results;
+    }
+
+}

--- a/src/test/java/org/jenkinsci/plugins/rundeck/RunDeckLogTailTest.java
+++ b/src/test/java/org/jenkinsci/plugins/rundeck/RunDeckLogTailTest.java
@@ -8,6 +8,7 @@ import static org.junit.Assert.fail;
 import java.util.ArrayList;
 import java.util.List;
 
+import mockit.Expectations;
 import mockit.Mocked;
 import mockit.NonStrictExpectations;
 
@@ -48,14 +49,13 @@ public class RunDeckLogTailTest {
         new NonStrictExpectations() {
             {
                 //@formatter:off
-                rundeckClient.getExecutionOutput(EXECUTION_ID, 0, anyLong, 2); result = rundeckOutput;
-                rundeckClient.getExecutionOutput(EXECUTION_ID, 50, 2000L, 2); result = rundeckOutput;
-                rundeckClient.getExecutionOutput(EXECUTION_ID, 100, 3000L, 2); result = rundeckOutput;
+                rundeckClient.getExecutionOutputState(EXECUTION_ID, false, 0, anyLong, 2); result = rundeckOutput;
+                rundeckClient.getExecutionOutputState(EXECUTION_ID, false, 50, anyLong, 2); result = rundeckOutput;
+                rundeckClient.getExecutionOutputState(EXECUTION_ID, false, 100, anyLong, 2); result = rundeckOutput;
                 rundeckOutput.getOffset(); returns(50, 100, 150);
-                rundeckOutput.getLastModified(); returns(1000L, 2000L, 3000L);
+                rundeckOutput.isExecCompleted(); returns (false, false, true);
                 rundeckOutput.getLogEntries(); returns(createLogEntries(new String[] {"lorem", "ipsum"}), createLogEntries(new String[] {"dolar", "sit"}), createLogEntries(new String[] {"amet"}));;
                 rundeckOutput.isCompleted(); returns (false, false, true);
-                rundeckOutput.isUnmodified(); returns (false, false);
                 //@formatter:on
             }
         };
@@ -77,10 +77,10 @@ public class RunDeckLogTailTest {
 
     @Test
     public void apiExceptionWillBeCaughtThreeTimesAndThenThrown() throws InterruptedException {
-        new NonStrictExpectations() {
+        new Expectations() {
             {
                 //@formatter:off
-                rundeckClient.getExecutionOutput(EXECUTION_ID, 0, anyLong, 2); result = new RundeckApiException("fail!"); times = 4;
+                rundeckClient.getExecutionOutputState(EXECUTION_ID, false, 0, anyLong, 2); result = new RundeckApiException("fail!"); times = 4;
                 //@formatter:on
             }
         };
@@ -111,14 +111,11 @@ public class RunDeckLogTailTest {
             @Mocked({ "sleep", "interrupt" })
             final Thread unused = null;
             {
-
                 //@formatter:off
-                rundeckClient.getExecutionOutput(EXECUTION_ID, 0, anyLong, 2); result = rundeckOutput;
+                rundeckClient.getExecutionOutputState(EXECUTION_ID, false, 0, anyLong, 2); result = rundeckOutput;
                 rundeckOutput.getOffset(); returns(50);
-                rundeckOutput.getLastModified(); returns(1000L);
                 rundeckOutput.getLogEntries(); returns(createLogEntries(new String[] {"lorem", "ipsum"}));
                 rundeckOutput.isCompleted(); returns (false);
-                rundeckOutput.isUnmodified(); returns (false);
                 Thread.sleep(anyLong); result= new InterruptedException();
                 onInstance(Thread.currentThread()).interrupt();
                 //@formatter:on
@@ -138,14 +135,13 @@ public class RunDeckLogTailTest {
         new NonStrictExpectations() {
             {
                 //@formatter:off
-                rundeckClient.getExecutionOutput(EXECUTION_ID, 0, 0L, 2); result = rundeckOutput;
-                rundeckClient.getExecutionOutput(EXECUTION_ID, 0, 0L, 2); result = rundeckOutput;
-                rundeckClient.getExecutionOutput(EXECUTION_ID, 50, 2000L, 2); result = rundeckOutput;
+                rundeckClient.getExecutionOutputState(EXECUTION_ID, false, 0, 0L, 2); result = rundeckOutput;
+                rundeckClient.getExecutionOutputState(EXECUTION_ID, false, 0, anyLong, 2); result = rundeckOutput;
+                rundeckClient.getExecutionOutputState(EXECUTION_ID, false, 50, anyLong, 2); result = rundeckOutput;
                 rundeckOutput.getOffset(); returns(0, 50, 100);
-                rundeckOutput.getLastModified(); returns(null, 1000L, 2000L);
                 rundeckOutput.getLogEntries(); returns(createLogEntries(new String[] {}), createLogEntries(new String[] {}), createLogEntries(new String[] {"dolar", "sit", "amet"}));;
                 rundeckOutput.isCompleted(); returns (null, false, true);
-                rundeckOutput.isUnmodified(); returns (false, true);
+                rundeckOutput.isExecCompleted(); returns (null, false, true);
                 //@formatter:on
             }
         };
@@ -170,14 +166,13 @@ public class RunDeckLogTailTest {
         new NonStrictExpectations() {
             {
                 //@formatter:off
-                rundeckClient.getExecutionOutput(EXECUTION_ID, 0, anyLong, 2); result = rundeckOutput;
-                rundeckClient.getExecutionOutput(EXECUTION_ID, 50, 2000L, 2); result = rundeckOutput;
-                rundeckClient.getExecutionOutput(EXECUTION_ID, 50, 2000L, 2); result = rundeckOutput;
+                rundeckClient.getExecutionOutputState(EXECUTION_ID, false, 0, anyLong, 2); result = rundeckOutput;
+                rundeckClient.getExecutionOutputState(EXECUTION_ID, false, 50, anyLong, 2); result = rundeckOutput;
+                rundeckClient.getExecutionOutputState(EXECUTION_ID, false, 50, anyLong, 2); result = rundeckOutput;
                 rundeckOutput.getOffset(); returns(50, 50, 150);
-                rundeckOutput.getLastModified(); returns(1000L, 1000L, 3000L);
                 rundeckOutput.getLogEntries(); returns(createLogEntries(new String[] {"lorem", "ipsum"}), createLogEntries(new String[] {}), createLogEntries(new String[] {"dolar", "sit", "amet"}));;
                 rundeckOutput.isCompleted(); returns (false, false, true);
-                rundeckOutput.isUnmodified(); returns (false, true);
+                rundeckOutput.isExecCompleted(); returns (false, false, true);
                 //@formatter:on
             }
         };

--- a/src/test/java/org/jenkinsci/plugins/rundeck/RunDeckLogTailTest.java
+++ b/src/test/java/org/jenkinsci/plugins/rundeck/RunDeckLogTailTest.java
@@ -102,9 +102,8 @@ public class RunDeckLogTailTest {
         } catch (RundeckApiException e) {
             assertEquals("fail!", e.getMessage());
         }
-
     }
-
+    
     @Test
     public void iteratorIsInterrupted() throws InterruptedException {
         new NonStrictExpectations() {
@@ -199,7 +198,7 @@ public class RunDeckLogTailTest {
     }
 
     public void assertMessagesPresentInOrder(List<RundeckOutputEntry> rundeckOutputEntries, String... messages) {
-
+        assertEquals(rundeckOutputEntries.size(), messages.length);
         int i = 0;
         for (RundeckOutputEntry rundeckOutputEntry : rundeckOutputEntries) {
             assertEquals(rundeckOutputEntry.getMessage(), messages[i]);


### PR DESCRIPTION
This change will add an (optional) log tailing implementation to the RunDeck Jenkins plugin. It is a blocking log tailer that will run for as long as the API is responsive and the API call says the log isn't completed. 

It is based on the pseudo code at http://rundeck.org/2.4.0/api/index.html#tailing-output
