### PR TITLE
added call to set the build result to failure when rundeck fails AND …

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/rundeck/RundeckNotifier.java
+++ b/src/main/java/org/jenkinsci/plugins/rundeck/RundeckNotifier.java
@@ -220,6 +220,8 @@ public class RundeckNotifier extends Notifier {
                         return true;
                     case ABORTED:
                     case FAILED:
+                        if (getShouldFailTheBuild())
+                           build.setResult(Result.FAILURE);
                         return false;
                     default:
                         return true;


### PR DESCRIPTION
Hi Greg,

I've created a pull request for consideration...

Although this plugin, when configured, is able to fail the jenkins build job upon rundeck job failure, this plugin only "marks" the job as FAILURE as opposed to immediately setting the build result.   The following jenkins messages illustrate the difference:

> Build step 'Rundeck' changed build result to FAILURE
> Build step 'Rundeck' marked build as failure

The second message is what we get w/o this change.  The first message is a bit more interesting as it allows subsequent plugins to know the status of the build before the jenkins job is completed.   I just implemented a plugin, whose behavior depends on the build result.   This result is either not knowable or perhaps inconsistent, unless the following code is implemented in the FAILED case:

>                    case FAILED:
>                        if (getShouldFailTheBuild())
>                           build.setResult(Result.FAILURE);

This allows the build result to be depended on before the job is complete (and if shouldFailTheBuild is enabled).  Without the setResult call, the job is simply marked for failure where the build result is not known until, it appears,  the very end.   This pull request mitigates this issue.  

The following:

https://blog.codecentric.de/en/2013/02/tutorial-jenkins-plugin-development/

is one of many examples which does set this result call.
