### PR TITLE
Use display name for the build name

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/rundeck/OptionProvider.java
+++ b/src/main/java/org/jenkinsci/plugins/rundeck/OptionProvider.java
@@ -114,7 +114,7 @@ public class OptionProvider {
         for (Run<?, ?> build : builds) {
             Artifact artifact = findArtifact(artifactName, artifactPattern, build);
             if (artifact != null) {
-                String buildName = "#" + build.getNumber() + " - " + build.getTimestampString2();
+                String buildName = build.getDisplayName();
                 options.add(new Option(buildName, buildArtifactUrl(build, artifact)));
             }
 


### PR DESCRIPTION
This is to support the build name setter plugin which allows you to customize the display name: https://wiki.jenkins-ci.org/display/JENKINS/Build+Name+Setter+Plugin