### PR TITLE
[JENKINS-34510] Caching Rundeck requests on startup

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
     </parent>
 
     <artifactId>rundeck</artifactId>
-    <version>3.5.3-SNAPSHOT</version>
+    <version>3.6.0-SNAPSHOT</version>
     <packaging>hpi</packaging>
 
     <name>Jenkins Rundeck plugin</name>

--- a/pom.xml
+++ b/pom.xml
@@ -168,6 +168,11 @@
             <version>2.6</version>
         </dependency>
         <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+            <version>11.0.1</version>
+        </dependency>
+        <dependency>
             <groupId>org.jmockit</groupId>
             <artifactId>jmockit</artifactId>
             <version>1.17</version>

--- a/pom.xml
+++ b/pom.xml
@@ -62,6 +62,14 @@
                     <reuseForks>false</reuseForks>
                 </configuration>
             </plugin>
+            <plugin>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.5.1</version>
+                <configuration>
+                    <source>1.7</source>
+                    <target>1.7</target>
+                </configuration>
+            </plugin>
         </plugins>
         <pluginManagement>
             <plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -175,7 +175,7 @@
         <dependency>
             <groupId>org.jmockit</groupId>
             <artifactId>jmockit</artifactId>
-            <version>1.17</version>
+            <version>1.16</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/src/main/java/org/jenkinsci/plugins/rundeck/RundeckJobProjectLinkerAction.java
+++ b/src/main/java/org/jenkinsci/plugins/rundeck/RundeckJobProjectLinkerAction.java
@@ -24,18 +24,19 @@ public class RundeckJobProjectLinkerAction implements Action {
     /**
      * Load the Rundeck job details (name, description, and so on) using the Rundeck API.
      * 
+     * @param rundeckInstanceName Rundeck instance name
      * @param rundeck client used for talking to the Rundeck API
      * @param rundeckJobId ID of the Rundeck job
      * @throws RundeckApiException in case of error while loading the job details from Rundeck API
      * @throws IllegalArgumentException if rundeck or rundeckJobId is null
      */
-    public RundeckJobProjectLinkerAction(RundeckClient rundeck, String rundeckJobId) throws RundeckApiException,
+    public RundeckJobProjectLinkerAction(String rundeckInstanceName, RundeckClient rundeck, String rundeckJobId) throws RundeckApiException,
             IllegalArgumentException {
         if (rundeck == null) {
             throw new IllegalArgumentException("rundeckClient should not be null !");
         }
         this.rundeck = rundeck;
-        this.rundeckJob = RundeckNotifier.RundeckDescriptor.findJob(rundeckJobId, rundeck);
+        this.rundeckJob = RundeckNotifier.RundeckDescriptor.findJob(rundeckJobId, rundeckInstanceName, rundeck);
         this.rundeckJobUrl = buildRundeckJobUrl();
     }
 

--- a/src/main/java/org/jenkinsci/plugins/rundeck/RundeckJobProjectLinkerAction.java
+++ b/src/main/java/org/jenkinsci/plugins/rundeck/RundeckJobProjectLinkerAction.java
@@ -15,6 +15,8 @@ import org.rundeck.api.domain.RundeckJob;
  */
 public class RundeckJobProjectLinkerAction implements Action {
 
+    private final String rundeckInstanceName;
+
     private final RundeckClient rundeck;
 
     private final RundeckJob rundeckJob;
@@ -35,6 +37,7 @@ public class RundeckJobProjectLinkerAction implements Action {
         if (rundeck == null) {
             throw new IllegalArgumentException("rundeckClient should not be null !");
         }
+        this.rundeckInstanceName = rundeckInstanceName;
         this.rundeck = rundeck;
         this.rundeckJob = RundeckNotifier.RundeckDescriptor.findJob(rundeckJobId, rundeckInstanceName, rundeck);
         this.rundeckJobUrl = buildRundeckJobUrl();
@@ -73,4 +76,7 @@ public class RundeckJobProjectLinkerAction implements Action {
         return rundeckJobUrl;
     }
 
+    public String getInstanceName() {
+        return rundeckInstanceName;
+    }
 }

--- a/src/main/java/org/jenkinsci/plugins/rundeck/RundeckNotifier.java
+++ b/src/main/java/org/jenkinsci/plugins/rundeck/RundeckNotifier.java
@@ -80,7 +80,7 @@ public class RundeckNotifier extends Notifier {
 
     private static final int DELAY_BETWEEN_POLLS_IN_MILLIS = 5000;
 
-    private String rundeckInstance; //TODO: Rename to rundeckInstanceName
+    private String rundeckInstance; //TODO: Could be renamed to rundeckInstanceName
 
     private final String jobId;
 
@@ -683,7 +683,7 @@ public class RundeckNotifier extends Notifier {
          */
         static String findJobId(String jobIdentifier, RundeckClient rundeckClient) throws RundeckApiException,
                 IllegalArgumentException {
-            logInfoWithThreadId(format("findJobId request for jobId: %s", jobIdentifier)); //TODO: Change to FINE
+            log.fine(format("findJobId request for jobId: %s", jobIdentifier));
             //TODO: Could be rewritten to be cache as well, if needed
             Matcher matcher = JOB_REFERENCE_PATTERN.matcher(jobIdentifier);
             if (matcher.find() && matcher.groupCount() == 3) {
@@ -714,9 +714,9 @@ public class RundeckNotifier extends Notifier {
         public static RundeckJob findJobUncached(String jobIdentifier, RundeckClient rundeckInstance) throws RundeckApiException, IllegalArgumentException {
             RundeckJobCacheConfig rundeckJobCacheConfig = getRundeckDescriptor().getRundeckJobCacheConfig();
             if (rundeckJobCacheConfig.isEnabled()) {
-                logInfoWithThreadId(format("NOT CACHED findJobUncached request for jobId: %s", jobIdentifier));
+                log.info(format("NOT CACHED findJobUncached request for jobId: %s", jobIdentifier));
             } else {
-                log.info(format("findJobUncached request for jobId: %s (cache disabled)", jobIdentifier));  //TODO: Change to FINE
+                log.fine(format("findJobUncached request for jobId: %s (cache disabled)", jobIdentifier));
             }
             Matcher matcher = JOB_REFERENCE_PATTERN.matcher(jobIdentifier);
             if (matcher.find() && matcher.groupCount() == 3) {
@@ -829,10 +829,5 @@ public class RundeckNotifier extends Notifier {
 
     private static RundeckDescriptor getRundeckDescriptor() {
         return Jenkins.getInstance().getExtensionList(RundeckDescriptor.class).get(0);
-    }
-
-    //TODO: Remove
-    private static void logInfoWithThreadId(String message) {
-        log.info(format("%d: %s", Thread.currentThread().getId(), message));
     }
 }

--- a/src/main/java/org/jenkinsci/plugins/rundeck/RundeckNotifier.java
+++ b/src/main/java/org/jenkinsci/plugins/rundeck/RundeckNotifier.java
@@ -515,6 +515,16 @@ public class RundeckNotifier extends Notifier {
                 instance.put("Default", rundeckInstance);
                 this.setRundeckInstances(instance);
             }
+
+            if (rundeckJobCacheConfig.getAfterAccessExpirationInMinutes() == null) {
+                rundeckJobCacheConfig.setAfterAccessExpirationInMinutes(17 * 60);
+            }
+            if (rundeckJobCacheConfig.getMaximumSize() == null) {
+                rundeckJobCacheConfig.setMaximumSize(499);
+            }
+            if (rundeckJobCacheConfig.getCacheStatsDisplayHitThreshold() == null) {
+                rundeckJobCacheConfig.setCacheStatsDisplayHitThreshold(180);
+            }
             return this;
         }
 

--- a/src/main/java/org/jenkinsci/plugins/rundeck/RundeckNotifier.java
+++ b/src/main/java/org/jenkinsci/plugins/rundeck/RundeckNotifier.java
@@ -493,9 +493,7 @@ public class RundeckNotifier extends Notifier {
         }
 
         public synchronized void load() {
-            System.out.println("======= Before super.load " + rundeckJobCacheConfig.isEnabled() + rundeckJobCacheConfig.getJobDetailsAfterWriteExpirationInMinutes());
             super.load();
-            System.out.println("======= After super.load " + rundeckJobCacheConfig.isEnabled() + rundeckJobCacheConfig.getJobDetailsAfterWriteExpirationInMinutes());
             initializeRundeckJobCache();
         }
 

--- a/src/main/java/org/jenkinsci/plugins/rundeck/RundeckNotifier.java
+++ b/src/main/java/org/jenkinsci/plugins/rundeck/RundeckNotifier.java
@@ -515,16 +515,6 @@ public class RundeckNotifier extends Notifier {
                 instance.put("Default", rundeckInstance);
                 this.setRundeckInstances(instance);
             }
-
-            if (rundeckJobCacheConfig.getAfterAccessExpirationInMinutes() == null) {
-                rundeckJobCacheConfig.setAfterAccessExpirationInMinutes(17 * 60);
-            }
-            if (rundeckJobCacheConfig.getMaximumSize() == null) {
-                rundeckJobCacheConfig.setMaximumSize(499);
-            }
-            if (rundeckJobCacheConfig.getCacheStatsDisplayHitThreshold() == null) {
-                rundeckJobCacheConfig.setCacheStatsDisplayHitThreshold(180);
-            }
             return this;
         }
 

--- a/src/main/java/org/jenkinsci/plugins/rundeck/cache/DummyRundeckJobCache.java
+++ b/src/main/java/org/jenkinsci/plugins/rundeck/cache/DummyRundeckJobCache.java
@@ -1,0 +1,14 @@
+package org.jenkinsci.plugins.rundeck.cache;
+
+import org.jenkinsci.plugins.rundeck.RundeckNotifier;
+import org.jenkinsci.plugins.rundeck.cache.IRundeckJobCache;
+import org.rundeck.api.RundeckClient;
+import org.rundeck.api.domain.RundeckJob;
+
+public class DummyRundeckJobCache implements IRundeckJobCache {
+
+    @Override
+    public RundeckJob findJobById(String rundeckJobId, String rundeckInstanceName, RundeckClient rundeckInstance) {
+        return RundeckNotifier.RundeckDescriptor.findJobUncached(rundeckJobId, rundeckInstance);
+    }
+}

--- a/src/main/java/org/jenkinsci/plugins/rundeck/cache/DummyRundeckJobCache.java
+++ b/src/main/java/org/jenkinsci/plugins/rundeck/cache/DummyRundeckJobCache.java
@@ -6,7 +6,7 @@ import org.jenkinsci.plugins.rundeck.RundeckNotifier;
 import org.rundeck.api.RundeckClient;
 import org.rundeck.api.domain.RundeckJob;
 
-public class DummyRundeckJobCache implements IRundeckJobCache {
+public class DummyRundeckJobCache implements RundeckJobCache {
 
     private static final Logger log = Logger.getLogger(DummyRundeckJobCache.class.getName());
 

--- a/src/main/java/org/jenkinsci/plugins/rundeck/cache/DummyRundeckJobCache.java
+++ b/src/main/java/org/jenkinsci/plugins/rundeck/cache/DummyRundeckJobCache.java
@@ -6,6 +6,12 @@ import org.jenkinsci.plugins.rundeck.RundeckNotifier;
 import org.rundeck.api.RundeckClient;
 import org.rundeck.api.domain.RundeckJob;
 
+/**
+ * Dummy Rundeck job cache implementation based. Used as a placeholder when caching is disabled.
+ *
+ * @author Marcin Zajączkowski
+ * @since 3.6.0
+ */
 public class DummyRundeckJobCache implements RundeckJobCache {
 
     private static final Logger log = Logger.getLogger(DummyRundeckJobCache.class.getName());

--- a/src/main/java/org/jenkinsci/plugins/rundeck/cache/DummyRundeckJobCache.java
+++ b/src/main/java/org/jenkinsci/plugins/rundeck/cache/DummyRundeckJobCache.java
@@ -1,14 +1,27 @@
 package org.jenkinsci.plugins.rundeck.cache;
 
+import java.util.logging.Logger;
+
 import org.jenkinsci.plugins.rundeck.RundeckNotifier;
-import org.jenkinsci.plugins.rundeck.cache.IRundeckJobCache;
 import org.rundeck.api.RundeckClient;
 import org.rundeck.api.domain.RundeckJob;
 
 public class DummyRundeckJobCache implements IRundeckJobCache {
 
+    private static final Logger log = Logger.getLogger(DummyRundeckJobCache.class.getName());
+
     @Override
     public RundeckJob findJobById(String rundeckJobId, String rundeckInstanceName, RundeckClient rundeckInstance) {
         return RundeckNotifier.RundeckDescriptor.findJobUncached(rundeckJobId, rundeckInstance);
+    }
+
+    @Override
+    public String logAndGetStats() {
+        return "0% hit rate for dummy cache";
+    }
+
+    @Override
+    public void invalidate() {
+        log.warning("Invalidation of dummy cache");
     }
 }

--- a/src/main/java/org/jenkinsci/plugins/rundeck/cache/IRundeckJobCache.java
+++ b/src/main/java/org/jenkinsci/plugins/rundeck/cache/IRundeckJobCache.java
@@ -1,0 +1,9 @@
+package org.jenkinsci.plugins.rundeck.cache;
+
+import org.rundeck.api.RundeckClient;
+import org.rundeck.api.domain.RundeckJob;
+
+public interface IRundeckJobCache {
+
+    RundeckJob findJobById(final String rundeckJobId, final String rundeckInstanceName, final RundeckClient rundeckInstance);
+}

--- a/src/main/java/org/jenkinsci/plugins/rundeck/cache/IRundeckJobCache.java
+++ b/src/main/java/org/jenkinsci/plugins/rundeck/cache/IRundeckJobCache.java
@@ -6,4 +6,8 @@ import org.rundeck.api.domain.RundeckJob;
 public interface IRundeckJobCache {
 
     RundeckJob findJobById(final String rundeckJobId, final String rundeckInstanceName, final RundeckClient rundeckInstance);
+
+    String logAndGetStats();
+
+    void invalidate();
 }

--- a/src/main/java/org/jenkinsci/plugins/rundeck/cache/InMemoryRundeckJobCache.java
+++ b/src/main/java/org/jenkinsci/plugins/rundeck/cache/InMemoryRundeckJobCache.java
@@ -21,14 +21,11 @@ import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
 import com.google.common.util.concurrent.UncheckedExecutionException;
 
-public final class InMemoryRundeckJobCache implements RundeckJobCache {
+public class InMemoryRundeckJobCache implements RundeckJobCache {
 
     private static final Logger log = Logger.getLogger(InMemoryRundeckJobCache.class.getName());
 
     private static final int RUNDECK_INSTANCE_CACHE_CONTAINER_EXPIRATION_IN_DAYS = 1;
-
-    //TODO: Remove that field - it is used only during the initialization
-    private final RundeckJobCacheConfig rundeckJobCacheConfig;
 
     private final int cacheStatsDisplayHitThreshold;
 
@@ -36,8 +33,8 @@ public final class InMemoryRundeckJobCache implements RundeckJobCache {
 
     private long hitCounter = 0;
 
-    public InMemoryRundeckJobCache(RundeckJobCacheConfig rundeckJobCacheConfig) {
-        this.rundeckJobCacheConfig = Objects.requireNonNull(rundeckJobCacheConfig);
+    public InMemoryRundeckJobCache(final RundeckJobCacheConfig rundeckJobCacheConfig) {
+        Objects.requireNonNull(rundeckJobCacheConfig);
         this.cacheStatsDisplayHitThreshold = rundeckJobCacheConfig.getCacheStatsDisplayHitThreshold();
         this.rundeckJobInstanceAwareCache = CacheBuilder.newBuilder()
                 .expireAfterAccess(RUNDECK_INSTANCE_CACHE_CONTAINER_EXPIRATION_IN_DAYS, TimeUnit.DAYS)    //just in case given instance was removed
@@ -45,12 +42,12 @@ public final class InMemoryRundeckJobCache implements RundeckJobCache {
                         new CacheLoader<String, Cache<String, RundeckJob>>() {
                             @Override
                             public Cache<String, RundeckJob> load(String rundeckInstanceName) throws Exception {
-                                return createJobCacheForRundeckInstance(rundeckInstanceName);
+                                return createJobCacheForRundeckInstance(rundeckInstanceName, rundeckJobCacheConfig);
                             }
                         });
     }
 
-    private Cache<String, RundeckJob> createJobCacheForRundeckInstance(String rundeckInstanceName) {
+    private Cache<String, RundeckJob> createJobCacheForRundeckInstance(String rundeckInstanceName, RundeckJobCacheConfig rundeckJobCacheConfig) {
         logInfoWithThreadId(format("Loading (GENERATING) jobs cache container for Rundeck instance %s", rundeckInstanceName));
         return CacheBuilder.newBuilder()
                 .expireAfterAccess(rundeckJobCacheConfig.getAfterAccessExpirationInMinutes(), TimeUnit.MINUTES)

--- a/src/main/java/org/jenkinsci/plugins/rundeck/cache/InMemoryRundeckJobCache.java
+++ b/src/main/java/org/jenkinsci/plugins/rundeck/cache/InMemoryRundeckJobCache.java
@@ -21,6 +21,12 @@ import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
 import com.google.common.util.concurrent.UncheckedExecutionException;
 
+/**
+ * In-memory Rundeck job cache implementation based on Cache from Guava.
+ *
+ * @author Marcin Zajączkowski
+ * @since 3.6.0
+ */
 public class InMemoryRundeckJobCache implements RundeckJobCache {
 
     private static final Logger log = Logger.getLogger(InMemoryRundeckJobCache.class.getName());
@@ -48,7 +54,7 @@ public class InMemoryRundeckJobCache implements RundeckJobCache {
     }
 
     private Cache<String, RundeckJob> createJobCacheForRundeckInstance(String rundeckInstanceName, RundeckJobCacheConfig rundeckJobCacheConfig) {
-        logInfoWithThreadId(format("Loading (GENERATING) jobs cache container for Rundeck instance %s", rundeckInstanceName));
+        log.info(format("Loading (GENERATING) jobs cache container for Rundeck instance %s", rundeckInstanceName));
         return CacheBuilder.newBuilder()
                 .expireAfterAccess(rundeckJobCacheConfig.getAfterAccessExpirationInMinutes(), TimeUnit.MINUTES)
                 .maximumSize(rundeckJobCacheConfig.getMaximumSize())
@@ -57,7 +63,7 @@ public class InMemoryRundeckJobCache implements RundeckJobCache {
 
     public RundeckJob findJobById(final String rundeckJobId, final String rundeckInstanceName, final RundeckClient rundeckInstance) {
         try {
-            logInfoWithThreadId(format("Cached findJob request for jobId: %s (%s)", rundeckJobId, rundeckInstanceName));   //TODO: Change to FINE
+            log.fine(format("Cached findJob request for jobId: %s (%s)", rundeckJobId, rundeckInstanceName));
             return findByJobIdInCacheOrAskServer(rundeckJobId, rundeckInstanceName, rundeckInstance);
         } catch (UncheckedExecutionException | ExecutionException e) {
             throw rethrowUnwrappingRundeckApiExceptionIfPossible(e);
@@ -117,12 +123,6 @@ public class InMemoryRundeckJobCache implements RundeckJobCache {
     }
 
     private void logCacheStats(String instanceName, Cache<String, ?> jobCache) {
-        logInfoWithThreadId(format("%s: %s", instanceName, jobCache.stats()));
+        log.info(format("%s: %s", instanceName, jobCache.stats()));
     }
-
-    //TODO: Remove
-    private static void logInfoWithThreadId(String message) {
-        log.info(format("%d: %s", Thread.currentThread().getId(), message));
-    }
-
 }

--- a/src/main/java/org/jenkinsci/plugins/rundeck/cache/InMemoryRundeckJobCache.java
+++ b/src/main/java/org/jenkinsci/plugins/rundeck/cache/InMemoryRundeckJobCache.java
@@ -1,0 +1,129 @@
+package org.jenkinsci.plugins.rundeck.cache;
+
+import static java.lang.String.format;
+
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.logging.Logger;
+
+import org.jenkinsci.plugins.rundeck.RundeckNotifier;
+import org.rundeck.api.RundeckApiException;
+import org.rundeck.api.RundeckClient;
+import org.rundeck.api.domain.RundeckJob;
+
+import com.google.common.base.Throwables;
+import com.google.common.cache.Cache;
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.CacheLoader;
+import com.google.common.cache.LoadingCache;
+import com.google.common.util.concurrent.UncheckedExecutionException;
+
+public final class InMemoryRundeckJobCache implements RundeckJobCache {
+
+    private static final Logger log = Logger.getLogger(InMemoryRundeckJobCache.class.getName());
+
+    //TODO: Make it configurable
+    private static final int RUNDECK_INSTANCE_CACHE_CONTAINER_EXPIRATION_IN_DAYS = 1;
+
+    private static final int CACHE_STATS_DISPLAY_THRESHOLD = 50;
+
+    private final RundeckJobCacheConfig rundeckJobCacheConfig;
+
+    private long callCounter = 0;
+
+    private LoadingCache<String, Cache<String, RundeckJob>> rundeckJobInstanceAwareCache;
+
+    public InMemoryRundeckJobCache(RundeckJobCacheConfig rundeckJobCacheConfig) {
+        this.rundeckJobCacheConfig = Objects.requireNonNull(rundeckJobCacheConfig);
+        this.rundeckJobInstanceAwareCache = CacheBuilder.newBuilder()
+                .expireAfterAccess(RUNDECK_INSTANCE_CACHE_CONTAINER_EXPIRATION_IN_DAYS, TimeUnit.DAYS)    //just in case given instance was removed
+                .build(
+                        new CacheLoader<String, Cache<String, RundeckJob>>() {
+                            @Override
+                            public Cache<String, RundeckJob> load(String rundeckInstanceName) throws Exception {
+                                return createJobCacheForRundeckInstance(rundeckInstanceName);
+                            }
+                        });
+    }
+
+    private Cache<String, RundeckJob> createJobCacheForRundeckInstance(String rundeckInstanceName) {
+        logInfoWithThreadId(format("Loading (GENERATING) jobs cache container for Rundeck instance %s", rundeckInstanceName));
+        return CacheBuilder.newBuilder()
+                .expireAfterWrite(rundeckJobCacheConfig.getJobDetailsAfterWriteExpirationInMinutes(), TimeUnit.MINUTES)
+                .build();
+    }
+
+    public RundeckJob findJobById(final String rundeckJobId, final String rundeckInstanceName, final RundeckClient rundeckInstance) {
+        try {
+            logInfoWithThreadId(format("Cached findJob request for jobId: %s (%s)", rundeckJobId, rundeckInstanceName));   //TODO: Change to FINE
+            return findByJobIdInCacheOrAskServer(rundeckJobId, rundeckInstanceName, rundeckInstance);
+        } catch (UncheckedExecutionException | ExecutionException e) {
+            throw rethrowUnwrappingRundeckApiExceptionIfPossible(e);
+        }
+    }
+
+    @Override
+    public String logAndGetStats() {
+        return logStatsAndReturnsAsString();
+    }
+
+    private String logStatsAndReturnsAsString() {
+        StringBuilder sb = new StringBuilder();
+        if (rundeckJobInstanceAwareCache.size() == 0) {
+            sb.append("Cache is empty");
+        } else {
+            for(Map.Entry<String, Cache<String, RundeckJob>> instanceCacheEntries: rundeckJobInstanceAwareCache.asMap().entrySet()) {
+                logCacheStats(instanceCacheEntries.getKey(), instanceCacheEntries.getValue());
+                sb.append(format("%s: %s", instanceCacheEntries.getKey(), instanceCacheEntries.getValue().stats()));
+            }
+        }
+        logCacheStats("Meta", rundeckJobInstanceAwareCache);
+        return sb.toString();
+    }
+
+    @Override
+    public void invalidate() {
+        logStatsAndReturnsAsString();
+        log.info("Rundeck job cache invalidation");
+        rundeckJobInstanceAwareCache.invalidateAll();
+    }
+
+    private RundeckJob findByJobIdInCacheOrAskServer(final String rundeckJobId, String rundeckInstanceName,
+                                                     final RundeckClient rundeckInstance) throws ExecutionException {
+        Cache<String, RundeckJob> rundeckJobCache = rundeckJobInstanceAwareCache.get(rundeckInstanceName);
+
+        RundeckJob tmp = rundeckJobCache.get(rundeckJobId, new Callable<RundeckJob>() {
+            public RundeckJob call() throws Exception {
+                return RundeckNotifier.RundeckDescriptor.findJobUncached(rundeckJobId, rundeckInstance);
+            }
+        });
+        logCacheStatsIfAppropriate(rundeckInstanceName, rundeckJobCache);
+        return tmp;
+    }
+
+    private RuntimeException rethrowUnwrappingRundeckApiExceptionIfPossible(Exception e) {
+        if (e.getCause() != null && e.getCause() instanceof RundeckApiException) {
+            throw new RundeckApiException(e.getMessage(), e);
+        }
+        throw Throwables.propagate(e);
+    }
+
+    private void logCacheStatsIfAppropriate(String instanceName, Cache<String, RundeckJob> jobCache) {
+        if (++callCounter % CACHE_STATS_DISPLAY_THRESHOLD == 0) {
+            logCacheStats(instanceName, jobCache);
+        }
+    }
+
+    private void logCacheStats(String instanceName, Cache<String, ?> jobCache) {
+        logInfoWithThreadId(format("%s: %s", instanceName, jobCache.stats()));
+    }
+
+    //TODO: Remove
+    private static void logInfoWithThreadId(String message) {
+        log.info(format("%d: %s", Thread.currentThread().getId(), message));
+    }
+
+}

--- a/src/main/java/org/jenkinsci/plugins/rundeck/cache/InMemoryRundeckJobCache.java
+++ b/src/main/java/org/jenkinsci/plugins/rundeck/cache/InMemoryRundeckJobCache.java
@@ -117,6 +117,9 @@ public class InMemoryRundeckJobCache implements RundeckJobCache {
     }
 
     private void logCacheStatsIfAppropriate(String instanceName, Cache<String, RundeckJob> jobCache) {
+        if (cacheStatsDisplayHitThreshold <= 0) {    //stats printing disabled
+            return;
+        }
         if (++hitCounter % cacheStatsDisplayHitThreshold == 0) {
             logCacheStats(instanceName, jobCache);
         }

--- a/src/main/java/org/jenkinsci/plugins/rundeck/cache/RundeckJobCache.java
+++ b/src/main/java/org/jenkinsci/plugins/rundeck/cache/RundeckJobCache.java
@@ -3,6 +3,12 @@ package org.jenkinsci.plugins.rundeck.cache;
 import org.rundeck.api.RundeckClient;
 import org.rundeck.api.domain.RundeckJob;
 
+/**
+ * Interface with operation for Rundeck job cache.
+ *
+ * @author Marcin Zajączkowski
+ * @since 3.6.0
+ */
 public interface RundeckJobCache {
 
     RundeckJob findJobById(final String rundeckJobId, final String rundeckInstanceName, final RundeckClient rundeckInstance);

--- a/src/main/java/org/jenkinsci/plugins/rundeck/cache/RundeckJobCache.java
+++ b/src/main/java/org/jenkinsci/plugins/rundeck/cache/RundeckJobCache.java
@@ -3,7 +3,7 @@ package org.jenkinsci.plugins.rundeck.cache;
 import org.rundeck.api.RundeckClient;
 import org.rundeck.api.domain.RundeckJob;
 
-public interface IRundeckJobCache {
+public interface RundeckJobCache {
 
     RundeckJob findJobById(final String rundeckJobId, final String rundeckInstanceName, final RundeckClient rundeckInstance);
 

--- a/src/main/java/org/jenkinsci/plugins/rundeck/cache/RundeckJobCacheConfig.java
+++ b/src/main/java/org/jenkinsci/plugins/rundeck/cache/RundeckJobCacheConfig.java
@@ -1,5 +1,11 @@
 package org.jenkinsci.plugins.rundeck.cache;
 
+/**
+ * Rundeck job cache configuration.
+ *
+ * @author Marcin Zajączkowski
+ * @since 3.6.0
+ */
 //TODO: Could be immutable with builder and copy constructor
 public class RundeckJobCacheConfig {
 

--- a/src/main/java/org/jenkinsci/plugins/rundeck/cache/RundeckJobCacheConfig.java
+++ b/src/main/java/org/jenkinsci/plugins/rundeck/cache/RundeckJobCacheConfig.java
@@ -1,0 +1,40 @@
+package org.jenkinsci.plugins.rundeck.cache;
+
+public class RundeckJobCacheConfig {
+
+    private boolean enabled = false;
+    private int jobDetailsAfterWriteExpirationInMinutes = 30;
+
+    public RundeckJobCacheConfig(boolean enabled, int jobDetailsAfterWriteExpirationInMinutes) {
+        this.enabled = enabled;
+        this.jobDetailsAfterWriteExpirationInMinutes = jobDetailsAfterWriteExpirationInMinutes;
+    }
+
+    private RundeckJobCacheConfig() {
+        System.out.println("======= RundeckJobCacheConfig created");
+    }
+
+    public void setEnabled(boolean enabled) {
+        this.enabled = enabled;
+    }
+
+    public boolean isEnabled() {
+        return enabled;
+    }
+
+    public int getJobDetailsAfterWriteExpirationInMinutes() {
+        return jobDetailsAfterWriteExpirationInMinutes;
+    }
+
+    public static RundeckJobCacheConfig initializeWithDefaultValues() {
+        return new RundeckJobCacheConfig();
+    }
+
+    @Override
+    public String toString() {
+        return "RundeckJobCacheConfig{" +
+                "enabled=" + enabled +
+                ", jobDetailsAfterWriteExpirationInMinutes=" + jobDetailsAfterWriteExpirationInMinutes +
+                '}';
+    }
+}

--- a/src/main/java/org/jenkinsci/plugins/rundeck/cache/RundeckJobCacheConfig.java
+++ b/src/main/java/org/jenkinsci/plugins/rundeck/cache/RundeckJobCacheConfig.java
@@ -11,7 +11,10 @@ public class RundeckJobCacheConfig {
     }
 
     private RundeckJobCacheConfig() {
-        System.out.println("======= RundeckJobCacheConfig created");
+    }
+
+    public static RundeckJobCacheConfig initializeWithDefaultValues() {
+        return new RundeckJobCacheConfig();
     }
 
     public void setEnabled(boolean enabled) {
@@ -24,10 +27,6 @@ public class RundeckJobCacheConfig {
 
     public int getJobDetailsAfterWriteExpirationInMinutes() {
         return jobDetailsAfterWriteExpirationInMinutes;
-    }
-
-    public static RundeckJobCacheConfig initializeWithDefaultValues() {
-        return new RundeckJobCacheConfig();
     }
 
     @Override

--- a/src/main/java/org/jenkinsci/plugins/rundeck/cache/RundeckJobCacheConfig.java
+++ b/src/main/java/org/jenkinsci/plugins/rundeck/cache/RundeckJobCacheConfig.java
@@ -3,7 +3,7 @@ package org.jenkinsci.plugins.rundeck.cache;
 public class RundeckJobCacheConfig {
 
     private boolean enabled = false;
-    private int jobDetailsAfterWriteExpirationInMinutes = 30;
+    private int jobDetailsAfterWriteExpirationInMinutes = 12 * 60;
 
     public RundeckJobCacheConfig(boolean enabled, int jobDetailsAfterWriteExpirationInMinutes) {
         this.enabled = enabled;

--- a/src/main/java/org/jenkinsci/plugins/rundeck/cache/RundeckJobCacheConfig.java
+++ b/src/main/java/org/jenkinsci/plugins/rundeck/cache/RundeckJobCacheConfig.java
@@ -1,14 +1,15 @@
 package org.jenkinsci.plugins.rundeck.cache;
 
+//TODO: Could be immutable with builder and copy constructor
 public class RundeckJobCacheConfig {
 
     private boolean enabled = false;
+    @Deprecated
     private int jobDetailsAfterWriteExpirationInMinutes = 12 * 60;
-
-    public RundeckJobCacheConfig(boolean enabled, int jobDetailsAfterWriteExpirationInMinutes) {
-        this.enabled = enabled;
-        this.jobDetailsAfterWriteExpirationInMinutes = jobDetailsAfterWriteExpirationInMinutes;
-    }
+    //TODO: Switch to int when all instances are migrated
+    private Integer afterAccessExpirationInMinutes = 18 * 60;
+    private Integer maximumSize = 500;
+    private Integer cacheStatsDisplayHitThreshold = 200;
 
     private RundeckJobCacheConfig() {
     }
@@ -29,11 +30,41 @@ public class RundeckJobCacheConfig {
         return jobDetailsAfterWriteExpirationInMinutes;
     }
 
+    public Integer getAfterAccessExpirationInMinutes() {
+        return afterAccessExpirationInMinutes;
+    }
+
+    @Deprecated
+    public void setAfterAccessExpirationInMinutes(Integer afterAccessExpirationInMinutes) {
+        this.afterAccessExpirationInMinutes = afterAccessExpirationInMinutes;
+    }
+
+    public Integer getMaximumSize() {
+        return maximumSize;
+    }
+
+    @Deprecated
+    public void setMaximumSize(Integer maximumSize) {
+        this.maximumSize = maximumSize;
+    }
+
+    public Integer getCacheStatsDisplayHitThreshold() {
+        return cacheStatsDisplayHitThreshold;
+    }
+
+    @Deprecated
+    public void setCacheStatsDisplayHitThreshold(Integer cacheStatsDisplayHitThreshold) {
+        this.cacheStatsDisplayHitThreshold = cacheStatsDisplayHitThreshold;
+    }
+
     @Override
     public String toString() {
         return "RundeckJobCacheConfig{" +
                 "enabled=" + enabled +
                 ", jobDetailsAfterWriteExpirationInMinutes=" + jobDetailsAfterWriteExpirationInMinutes +
+                ", afterAccessExpirationInMinutes=" + afterAccessExpirationInMinutes +
+                ", maximumSize=" + maximumSize +
+                ", cacheStatsDisplayHitThreshold=" + cacheStatsDisplayHitThreshold +
                 '}';
     }
 }

--- a/src/main/java/org/jenkinsci/plugins/rundeck/cache/RundeckJobCacheConfig.java
+++ b/src/main/java/org/jenkinsci/plugins/rundeck/cache/RundeckJobCacheConfig.java
@@ -4,12 +4,9 @@ package org.jenkinsci.plugins.rundeck.cache;
 public class RundeckJobCacheConfig {
 
     private boolean enabled = false;
-    @Deprecated
-    private int jobDetailsAfterWriteExpirationInMinutes = 12 * 60;
-    //TODO: Switch to int when all instances are migrated
-    private Integer afterAccessExpirationInMinutes = 18 * 60;
-    private Integer maximumSize = 500;
-    private Integer cacheStatsDisplayHitThreshold = 200;
+    private int afterAccessExpirationInMinutes = 18 * 60;
+    private int maximumSize = 500;
+    private int cacheStatsDisplayHitThreshold = 200;
 
     private RundeckJobCacheConfig() {
     }
@@ -26,42 +23,22 @@ public class RundeckJobCacheConfig {
         return enabled;
     }
 
-    public int getJobDetailsAfterWriteExpirationInMinutes() {
-        return jobDetailsAfterWriteExpirationInMinutes;
-    }
-
-    public Integer getAfterAccessExpirationInMinutes() {
+    public int getAfterAccessExpirationInMinutes() {
         return afterAccessExpirationInMinutes;
     }
 
-    @Deprecated
-    public void setAfterAccessExpirationInMinutes(Integer afterAccessExpirationInMinutes) {
-        this.afterAccessExpirationInMinutes = afterAccessExpirationInMinutes;
-    }
-
-    public Integer getMaximumSize() {
+    public int getMaximumSize() {
         return maximumSize;
     }
 
-    @Deprecated
-    public void setMaximumSize(Integer maximumSize) {
-        this.maximumSize = maximumSize;
-    }
-
-    public Integer getCacheStatsDisplayHitThreshold() {
+    public int getCacheStatsDisplayHitThreshold() {
         return cacheStatsDisplayHitThreshold;
-    }
-
-    @Deprecated
-    public void setCacheStatsDisplayHitThreshold(Integer cacheStatsDisplayHitThreshold) {
-        this.cacheStatsDisplayHitThreshold = cacheStatsDisplayHitThreshold;
     }
 
     @Override
     public String toString() {
         return "RundeckJobCacheConfig{" +
                 "enabled=" + enabled +
-                ", jobDetailsAfterWriteExpirationInMinutes=" + jobDetailsAfterWriteExpirationInMinutes +
                 ", afterAccessExpirationInMinutes=" + afterAccessExpirationInMinutes +
                 ", maximumSize=" + maximumSize +
                 ", cacheStatsDisplayHitThreshold=" + cacheStatsDisplayHitThreshold +

--- a/src/main/resources/org/jenkinsci/plugins/rundeck/RundeckJobProjectLinkerAction/jobMain.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/rundeck/RundeckJobProjectLinkerAction/jobMain.jelly
@@ -9,6 +9,7 @@
       <td style="vertical-align:middle">
         Associated <a href="http://rundeck.org/">Rundeck</a> Job:
         <a href="${it.urlName}">[${it.rundeckJob.project}] ${it.rundeckJob.fullName}</a>
+        (Instance: ${it.instanceName})
         <br />
         <em>${it.rundeckJob.description}</em>
       </td>

--- a/src/main/resources/org/jenkinsci/plugins/rundeck/RundeckNotifier/global.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/rundeck/RundeckNotifier/global.jelly
@@ -1,5 +1,12 @@
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <f:section title="Rundeck">
+    <f:entry title="Job cache" description="Rundeck job cache configuration">
+      <table width="100%">
+        <f:entry title="Enabled">
+          <f:checkbox name="rundeck.cache.enabled" checked="${descriptor.rundeckJobCacheConfig.enabled}"/>
+        </f:entry>
+      </table>
+    </f:entry>
     <f:entry title="Instances" description="List of Rundeck instances">
       <f:repeatable var="inst" items="${descriptor.rundeckInstances}" add="Add Rundeck">
         <table width="100%">

--- a/src/main/resources/org/jenkinsci/plugins/rundeck/RundeckNotifier/global.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/rundeck/RundeckNotifier/global.jelly
@@ -2,9 +2,12 @@
   <f:section title="Rundeck">
     <f:entry title="Job cache" description="Rundeck job cache configuration">
       <table width="100%">
-        <f:entry title="Enabled">
-          <f:checkbox name="rundeck.cache.enabled" checked="${descriptor.rundeckJobCacheConfig.enabled}"/>
-        </f:entry>
+        <f:block>
+          <f:optionalBlock name="rundeckJobCacheEnabled" title="Enable Rundeck job cache" checked="${descriptor.rundeckJobCacheConfig.enabled}">
+            <f:validateButton title="Cache statistics" method="displayCacheStatistics" with=""/>
+            <f:validateButton title="Invalidate cache" method="invalidateCache" with=""/>
+          </f:optionalBlock>
+        </f:block>
       </table>
     </f:entry>
     <f:entry title="Instances" description="List of Rundeck instances">

--- a/src/test/java/org/jenkinsci/plugins/rundeck/RundeckNotifierBackwardCompatibilityTest.java
+++ b/src/test/java/org/jenkinsci/plugins/rundeck/RundeckNotifierBackwardCompatibilityTest.java
@@ -35,8 +35,8 @@ public class RundeckNotifierBackwardCompatibilityTest extends HudsonTestCase {
         assertEquals("login", instance.getLogin());
         assertEquals("password", instance.getPassword());
         assertEquals("9", descriptor.getApiVersion(instance));
-        assertEquals(true, descriptor.getRundeckJobCacheConfig().isEnabled());
-        assertEquals(30, descriptor.getRundeckJobCacheConfig().getJobDetailsAfterWriteExpirationInMinutes());
+        assertEquals(false, descriptor.getRundeckJobCacheConfig().isEnabled());
+        assertEquals(720, descriptor.getRundeckJobCacheConfig().getJobDetailsAfterWriteExpirationInMinutes());
     }
     
     @LocalData
@@ -65,8 +65,8 @@ public class RundeckNotifierBackwardCompatibilityTest extends HudsonTestCase {
                 "    </entry>\n" + 
                 "  </rundeckInstances>\n" +
                 "  <rundeckJobCacheConfig>\n" +
-                "    <enabled>true</enabled>\n" +
-                "    <jobDetailsAfterWriteExpirationInMinutes>30</jobDetailsAfterWriteExpirationInMinutes>\n" +
+                "    <enabled>false</enabled>\n" +
+                "    <jobDetailsAfterWriteExpirationInMinutes>720</jobDetailsAfterWriteExpirationInMinutes>\n" +
                 "  </rundeckJobCacheConfig>\n" +
                 "</org.jenkinsci.plugins.rundeck.RundeckNotifier_-RundeckDescriptor>";
         
@@ -108,8 +108,8 @@ public class RundeckNotifierBackwardCompatibilityTest extends HudsonTestCase {
                 "    </entry>\n" + 
                 "  </rundeckInstances>\n" + 
                 "  <rundeckJobCacheConfig>\n" +
-                "    <enabled>true</enabled>\n" +
-                "    <jobDetailsAfterWriteExpirationInMinutes>30</jobDetailsAfterWriteExpirationInMinutes>\n" +
+                "    <enabled>false</enabled>\n" +
+                "    <jobDetailsAfterWriteExpirationInMinutes>720</jobDetailsAfterWriteExpirationInMinutes>\n" +
                 "  </rundeckJobCacheConfig>\n" +
                 "</org.jenkinsci.plugins.rundeck.RundeckNotifier_-RundeckDescriptor>";
         
@@ -177,8 +177,8 @@ public class RundeckNotifierBackwardCompatibilityTest extends HudsonTestCase {
     public void test_GivenADescriptorConfigWithoutCache_WhenInstanciatingDescriptorCacheWithDefaultValuesIsUsed() {
         RundeckDescriptor descriptor = (RundeckDescriptor) this.jenkins.getDescriptorOrDie(RundeckNotifier.class);
 
-        assertEquals(true, descriptor.getRundeckJobCacheConfig().isEnabled());
-        assertEquals(30, descriptor.getRundeckJobCacheConfig().getJobDetailsAfterWriteExpirationInMinutes());
+        assertEquals(false, descriptor.getRundeckJobCacheConfig().isEnabled());
+        assertEquals(720, descriptor.getRundeckJobCacheConfig().getJobDetailsAfterWriteExpirationInMinutes());
     }
 
     private FreeStyleProject getOldJob() {

--- a/src/test/java/org/jenkinsci/plugins/rundeck/RundeckNotifierBackwardCompatibilityTest.java
+++ b/src/test/java/org/jenkinsci/plugins/rundeck/RundeckNotifierBackwardCompatibilityTest.java
@@ -36,10 +36,9 @@ public class RundeckNotifierBackwardCompatibilityTest extends HudsonTestCase {
         assertEquals("password", instance.getPassword());
         assertEquals("9", descriptor.getApiVersion(instance));
         assertEquals(false, descriptor.getRundeckJobCacheConfig().isEnabled());
-        assertEquals(720, descriptor.getRundeckJobCacheConfig().getJobDetailsAfterWriteExpirationInMinutes());
-        assertEquals(1080, descriptor.getRundeckJobCacheConfig().getAfterAccessExpirationInMinutes().intValue());
-        assertEquals(500, descriptor.getRundeckJobCacheConfig().getMaximumSize().intValue());
-        assertEquals(200, descriptor.getRundeckJobCacheConfig().getCacheStatsDisplayHitThreshold().intValue());
+        assertEquals(1080, descriptor.getRundeckJobCacheConfig().getAfterAccessExpirationInMinutes());
+        assertEquals(500, descriptor.getRundeckJobCacheConfig().getMaximumSize());
+        assertEquals(200, descriptor.getRundeckJobCacheConfig().getCacheStatsDisplayHitThreshold());
     }
     
     @LocalData
@@ -69,7 +68,6 @@ public class RundeckNotifierBackwardCompatibilityTest extends HudsonTestCase {
                 "  </rundeckInstances>\n" +
                 "  <rundeckJobCacheConfig>\n" +
                 "    <enabled>false</enabled>\n" +
-                "    <jobDetailsAfterWriteExpirationInMinutes>720</jobDetailsAfterWriteExpirationInMinutes>\n" +
                 "    <afterAccessExpirationInMinutes>1080</afterAccessExpirationInMinutes>\n" +
                 "    <maximumSize>500</maximumSize>\n" +
                 "    <cacheStatsDisplayHitThreshold>200</cacheStatsDisplayHitThreshold>\n" +
@@ -115,7 +113,6 @@ public class RundeckNotifierBackwardCompatibilityTest extends HudsonTestCase {
                 "  </rundeckInstances>\n" + 
                 "  <rundeckJobCacheConfig>\n" +
                 "    <enabled>false</enabled>\n" +
-                "    <jobDetailsAfterWriteExpirationInMinutes>720</jobDetailsAfterWriteExpirationInMinutes>\n" +
                 "    <afterAccessExpirationInMinutes>1080</afterAccessExpirationInMinutes>\n" +
                 "    <maximumSize>500</maximumSize>\n" +
                 "    <cacheStatsDisplayHitThreshold>200</cacheStatsDisplayHitThreshold>\n" +
@@ -187,7 +184,9 @@ public class RundeckNotifierBackwardCompatibilityTest extends HudsonTestCase {
         RundeckDescriptor descriptor = (RundeckDescriptor) this.jenkins.getDescriptorOrDie(RundeckNotifier.class);
 
         assertEquals(false, descriptor.getRundeckJobCacheConfig().isEnabled());
-        assertEquals(720, descriptor.getRundeckJobCacheConfig().getJobDetailsAfterWriteExpirationInMinutes());
+        assertEquals(18 * 60, descriptor.getRundeckJobCacheConfig().getAfterAccessExpirationInMinutes());
+        assertEquals(500, descriptor.getRundeckJobCacheConfig().getMaximumSize());
+        assertEquals(200, descriptor.getRundeckJobCacheConfig().getCacheStatsDisplayHitThreshold());
     }
 
     private FreeStyleProject getOldJob() {

--- a/src/test/java/org/jenkinsci/plugins/rundeck/RundeckNotifierBackwardCompatibilityTest.java
+++ b/src/test/java/org/jenkinsci/plugins/rundeck/RundeckNotifierBackwardCompatibilityTest.java
@@ -35,6 +35,8 @@ public class RundeckNotifierBackwardCompatibilityTest extends HudsonTestCase {
         assertEquals("login", instance.getLogin());
         assertEquals("password", instance.getPassword());
         assertEquals("9", descriptor.getApiVersion(instance));
+        assertEquals(true, descriptor.getRundeckJobCacheConfig().isEnabled());
+        assertEquals(30, descriptor.getRundeckJobCacheConfig().getJobDetailsAfterWriteExpirationInMinutes());
     }
     
     @LocalData
@@ -42,7 +44,7 @@ public class RundeckNotifierBackwardCompatibilityTest extends HudsonTestCase {
         RundeckDescriptor descriptor = (RundeckDescriptor) this.jenkins.getDescriptorOrDie(RundeckNotifier.class);
         
         String oldStoredConfig = FileUtils.readFileToString(new File(this.jenkins.getRootDir(), descriptor.getId() + ".xml"));
-        
+
         descriptor.save();
         
         String storedConfig = FileUtils.readFileToString(new File(this.jenkins.getRootDir(), descriptor.getId() + ".xml"));
@@ -61,7 +63,11 @@ public class RundeckNotifierBackwardCompatibilityTest extends HudsonTestCase {
                 "        <password>password</password>\n" + 
                 "      </org.rundeck.api.RundeckClient>\n" + 
                 "    </entry>\n" + 
-                "  </rundeckInstances>\n" + 
+                "  </rundeckInstances>\n" +
+                "  <rundeckJobCacheConfig>\n" +
+                "    <enabled>true</enabled>\n" +
+                "    <jobDetailsAfterWriteExpirationInMinutes>30</jobDetailsAfterWriteExpirationInMinutes>\n" +
+                "  </rundeckJobCacheConfig>\n" +
                 "</org.jenkinsci.plugins.rundeck.RundeckNotifier_-RundeckDescriptor>";
         
         assertEquals(expected, storedConfig);
@@ -101,6 +107,10 @@ public class RundeckNotifierBackwardCompatibilityTest extends HudsonTestCase {
                 "      </org.rundeck.api.RundeckClient>\n" + 
                 "    </entry>\n" + 
                 "  </rundeckInstances>\n" + 
+                "  <rundeckJobCacheConfig>\n" +
+                "    <enabled>true</enabled>\n" +
+                "    <jobDetailsAfterWriteExpirationInMinutes>30</jobDetailsAfterWriteExpirationInMinutes>\n" +
+                "  </rundeckJobCacheConfig>\n" +
                 "</org.jenkinsci.plugins.rundeck.RundeckNotifier_-RundeckDescriptor>";
         
         assertEquals(expected, storedConfig);
@@ -162,7 +172,15 @@ public class RundeckNotifierBackwardCompatibilityTest extends HudsonTestCase {
         
         assertEquals(expected, storedConfig);
     }
-    
+
+    @LocalData
+    public void test_GivenADescriptorConfigWithoutCache_WhenInstanciatingDescriptorCacheWithDefaultValuesIsUsed() {
+        RundeckDescriptor descriptor = (RundeckDescriptor) this.jenkins.getDescriptorOrDie(RundeckNotifier.class);
+
+        assertEquals(true, descriptor.getRundeckJobCacheConfig().isEnabled());
+        assertEquals(30, descriptor.getRundeckJobCacheConfig().getJobDetailsAfterWriteExpirationInMinutes());
+    }
+
     private FreeStyleProject getOldJob() {
         return ((FreeStyleProject)this.jenkins.getItem("old"));
     }

--- a/src/test/java/org/jenkinsci/plugins/rundeck/RundeckNotifierBackwardCompatibilityTest.java
+++ b/src/test/java/org/jenkinsci/plugins/rundeck/RundeckNotifierBackwardCompatibilityTest.java
@@ -37,6 +37,9 @@ public class RundeckNotifierBackwardCompatibilityTest extends HudsonTestCase {
         assertEquals("9", descriptor.getApiVersion(instance));
         assertEquals(false, descriptor.getRundeckJobCacheConfig().isEnabled());
         assertEquals(720, descriptor.getRundeckJobCacheConfig().getJobDetailsAfterWriteExpirationInMinutes());
+        assertEquals(1080, descriptor.getRundeckJobCacheConfig().getAfterAccessExpirationInMinutes().intValue());
+        assertEquals(500, descriptor.getRundeckJobCacheConfig().getMaximumSize().intValue());
+        assertEquals(200, descriptor.getRundeckJobCacheConfig().getCacheStatsDisplayHitThreshold().intValue());
     }
     
     @LocalData
@@ -67,6 +70,9 @@ public class RundeckNotifierBackwardCompatibilityTest extends HudsonTestCase {
                 "  <rundeckJobCacheConfig>\n" +
                 "    <enabled>false</enabled>\n" +
                 "    <jobDetailsAfterWriteExpirationInMinutes>720</jobDetailsAfterWriteExpirationInMinutes>\n" +
+                "    <afterAccessExpirationInMinutes>1080</afterAccessExpirationInMinutes>\n" +
+                "    <maximumSize>500</maximumSize>\n" +
+                "    <cacheStatsDisplayHitThreshold>200</cacheStatsDisplayHitThreshold>\n" +
                 "  </rundeckJobCacheConfig>\n" +
                 "</org.jenkinsci.plugins.rundeck.RundeckNotifier_-RundeckDescriptor>";
         
@@ -110,6 +116,9 @@ public class RundeckNotifierBackwardCompatibilityTest extends HudsonTestCase {
                 "  <rundeckJobCacheConfig>\n" +
                 "    <enabled>false</enabled>\n" +
                 "    <jobDetailsAfterWriteExpirationInMinutes>720</jobDetailsAfterWriteExpirationInMinutes>\n" +
+                "    <afterAccessExpirationInMinutes>1080</afterAccessExpirationInMinutes>\n" +
+                "    <maximumSize>500</maximumSize>\n" +
+                "    <cacheStatsDisplayHitThreshold>200</cacheStatsDisplayHitThreshold>\n" +
                 "  </rundeckJobCacheConfig>\n" +
                 "</org.jenkinsci.plugins.rundeck.RundeckNotifier_-RundeckDescriptor>";
         
@@ -165,8 +174,8 @@ public class RundeckNotifierBackwardCompatibilityTest extends HudsonTestCase {
                 "      <shouldFailTheBuild>true</shouldFailTheBuild>\n" + 
                 "      <includeRundeckLogs>false</includeRundeckLogs>\n" + 
                 "      <tailLog>false</tailLog>\n" + 
-                "    </org.jenkinsci.plugins.rundeck.RundeckNotifier>\n" + 
-                "  </publishers>\n" + 
+                "    </org.jenkinsci.plugins.rundeck.RundeckNotifier>\n" +
+                "  </publishers>\n" +
                 "  <buildWrappers/>\n" + 
                 "</project>";
         


### PR DESCRIPTION
As described in [JENKINS-34510](https://issues.jenkins-ci.org/browse/JENKINS-34510) Jenkins startup time with 1500+ rundeck jobs can take multiple minutes due to 1500+ hit to Rundeck.

Proposed solution introduces in-memory cache for `findJob` method. Cache is implemented using Cache from Guava. Cache is disabled by default for backward compatibility. It can be enabled via Jenkins UI. In addition important parameters are configurable via XML. Cache stats and invalidation operations are available from Jenkins UI.

There are places in code that I'm not satisfies with, but Jenkins limitations (or my little knowledge about its internals) and/or an intention to reduce number of modified places in code held me back. Please do a code review and hopefully merge it into master.

Btw, to reduce boiler plate code in a few places I bump required Java version to 7 (which has been required by Jenkins since early 2015).