### PR TITLE
Add Jenkins Pipelines support to Rundeck Notifier

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>1.424</version>
+        <version>1.580.1</version>
     </parent>
 
     <artifactId>rundeck</artifactId>

--- a/src/test/java/org/jenkinsci/plugins/rundeck/RundeckNotifierBackwardCompatibilityTest.java
+++ b/src/test/java/org/jenkinsci/plugins/rundeck/RundeckNotifierBackwardCompatibilityTest.java
@@ -164,7 +164,7 @@ public class RundeckNotifierBackwardCompatibilityTest extends HudsonTestCase {
                 "  <disabled>false</disabled>\n" + 
                 "  <blockBuildWhenDownstreamBuilding>false</blockBuildWhenDownstreamBuilding>\n" + 
                 "  <blockBuildWhenUpstreamBuilding>false</blockBuildWhenUpstreamBuilding>\n" + 
-                "  <triggers class=\"vector\"/>\n" + 
+                "  <triggers/>\n" +
                 "  <concurrentBuild>false</concurrentBuild>\n" + 
                 "  <builders/>\n" + 
                 "  <publishers>\n" + 


### PR DESCRIPTION
This PR makes Rundeck Notifier compatible with Pipelines, allowing to trigger a Rundeck job as part of a build pipeline (typically for deployment).
Jenkins required version is now 1.580.1 as documented in Pipeline Dev Guide (https://github.com/jenkinsci/pipeline-plugin/blob/master/DEVGUIDE.md)
All tests are still passing, and I use the updated version for a few weeks to manage both staging and production deployment, everythings works fine.