### PR TITLE
Add support for notifying on non-success status

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/rundeck/RundeckNotifier.java
+++ b/src/main/java/org/jenkinsci/plugins/rundeck/RundeckNotifier.java
@@ -76,6 +76,8 @@ public class RundeckNotifier extends Notifier implements SimpleBuildStep {
 
     private final Boolean shouldFailTheBuild;
 
+    private final Boolean notifyOnAllStatus;
+
     private final Boolean includeRundeckLogs;
 
     private final Boolean tailLog;
@@ -87,15 +89,22 @@ public class RundeckNotifier extends Notifier implements SimpleBuildStep {
     /** rundeck user during job perform */
     private String performUser;
 
+    RundeckNotifier(String rundeckInstance, String jobId, String options, String nodeFilters, String tags,
+                    Boolean shouldWaitForRundeckJob, Boolean shouldFailTheBuild, Boolean includeRundeckLogs, Boolean tailLog,
+                    String jobUser, String jobPassword, String jobToken) {
+        this(rundeckInstance, jobId, options, nodeFilters, tags, shouldWaitForRundeckJob, shouldFailTheBuild, false, includeRundeckLogs, tailLog, jobUser, jobPassword, jobToken);
+    }
+
     RundeckNotifier(String rundeckInstance, String jobId, String options, String nodeFilters, String tag,
                     Boolean shouldWaitForRundeckJob, Boolean shouldFailTheBuild,
                     String jobUser, String jobPassword, String jobToken) {
-        this(rundeckInstance, jobId, options, nodeFilters, tag, shouldWaitForRundeckJob, shouldFailTheBuild, false, false, jobUser, jobPassword,jobToken);
+        this(rundeckInstance, jobId, options, nodeFilters, tag, shouldWaitForRundeckJob, shouldFailTheBuild, false, false, false, jobUser, jobPassword, jobToken);
     }
 
     @DataBoundConstructor
     public RundeckNotifier(String rundeckInstance, String jobId, String options, String nodeFilters, String tags,
-                           Boolean shouldWaitForRundeckJob, Boolean shouldFailTheBuild, Boolean includeRundeckLogs, Boolean tailLog,
+                           Boolean shouldWaitForRundeckJob, Boolean shouldFailTheBuild, Boolean notifyOnAllStatus,
+                           Boolean includeRundeckLogs, Boolean tailLog,
                            String jobUser, String jobPassword, String jobToken) {
         this.rundeckInstance = rundeckInstance;
         this.jobId = jobId;
@@ -105,6 +114,7 @@ public class RundeckNotifier extends Notifier implements SimpleBuildStep {
         this.tag = null;
         this.shouldWaitForRundeckJob = shouldWaitForRundeckJob;
         this.shouldFailTheBuild = shouldFailTheBuild;
+        this.notifyOnAllStatus = notifyOnAllStatus;
         this.includeRundeckLogs = includeRundeckLogs;
         this.tailLog = tailLog;
         this.jobUser = jobUser;
@@ -125,7 +135,7 @@ public class RundeckNotifier extends Notifier implements SimpleBuildStep {
 
     @Override
     public void perform(@Nonnull Run<?, ?> run, @Nonnull FilePath filePath, @Nonnull Launcher launcher, @Nonnull TaskListener listener) throws InterruptedException, IOException {
-        if (run.getResult() != Result.SUCCESS && run.getResult() != null) {
+        if (!Boolean.TRUE.equals(notifyOnAllStatus) && run.getResult() != Result.SUCCESS && run.getResult() != null) {
             return;
         }
 
@@ -480,6 +490,10 @@ public class RundeckNotifier extends Notifier implements SimpleBuildStep {
         return shouldFailTheBuild;
     }
 
+    public Boolean getNotifyOnAllStatus() {
+        return notifyOnAllStatus;
+    }
+
     public Boolean getIncludeRundeckLogs() {
         return includeRundeckLogs;
     }
@@ -635,6 +649,7 @@ public class RundeckNotifier extends Notifier implements SimpleBuildStep {
                     formData.getString("tag"),
                     formData.getBoolean("shouldWaitForRundeckJob"),
                     formData.getBoolean("shouldFailTheBuild"),
+                    formData.getBoolean("notifyOnAllStatus"),
                     formData.getBoolean("includeRundeckLogs"),
                     formData.getBoolean("tailLog"),
                     jobUser,

--- a/src/main/resources/org/jenkinsci/plugins/rundeck/RundeckNotifier/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/rundeck/RundeckNotifier/config.jelly
@@ -53,4 +53,7 @@
   <f:entry title="Should fail the build ?" field="shouldFailTheBuild">
     <f:checkbox />
   </f:entry>
+  <f:entry title="Should notify Rundeck regardless of status ?" field="notifyOnAllStatus">
+    <f:checkbox />
+  </f:entry>  
 </j:jelly>

--- a/src/main/resources/org/jenkinsci/plugins/rundeck/RundeckNotifier/help-notifyOnAllStatus.html
+++ b/src/main/resources/org/jenkinsci/plugins/rundeck/RundeckNotifier/help-notifyOnAllStatus.html
@@ -1,0 +1,5 @@
+<div>
+  Normally, Rundeck will only be notified on a SUCCESS status.
+  If checked, Rundeck will be notifed regardless of status.  This can be especially
+  useful in post.
+</div>

--- a/src/test/java/org/jenkinsci/plugins/rundeck/RundeckNotifierBackwardCompatibilityTest.java
+++ b/src/test/java/org/jenkinsci/plugins/rundeck/RundeckNotifierBackwardCompatibilityTest.java
@@ -181,6 +181,7 @@ public class RundeckNotifierBackwardCompatibilityTest extends HudsonTestCase {
                 "      </tags>\n" + 
                 "      <shouldWaitForRundeckJob>true</shouldWaitForRundeckJob>\n" + 
                 "      <shouldFailTheBuild>true</shouldFailTheBuild>\n" + 
+                "      <notifyOnAllStatus>false</notifyOnAllStatus>\n" +
                 "      <includeRundeckLogs>false</includeRundeckLogs>\n" + 
                 "      <tailLog>false</tailLog>\n" + 
                 "    </org.jenkinsci.plugins.rundeck.RundeckNotifier>\n" +

--- a/src/test/resources/org/jenkinsci/plugins/rundeck/RundeckNotifierBackwardCompatibilityTest/jobs/old/config.xml
+++ b/src/test/resources/org/jenkinsci/plugins/rundeck/RundeckNotifierBackwardCompatibilityTest/jobs/old/config.xml
@@ -20,6 +20,7 @@
       <tag>test</tag>
       <shouldWaitForRundeckJob>true</shouldWaitForRundeckJob>
       <shouldFailTheBuild>true</shouldFailTheBuild>
+      <notifyOnAllStatus>false</notifyOnAllStatus>
       <includeRundeckLogs>false</includeRundeckLogs>
       <tailLog>false</tailLog>
     </org.jenkinsci.plugins.rundeck.RundeckNotifier>


### PR DESCRIPTION
Hi folk!  We have a use case where we'd like to be able to trigger the rundeck notifier on any status, failure, success, doesn't matter, in post.  Currently, there is a specific check for "is the status success" in place that prevents us from doing that.

This PR adds a new option, notifyOnlyOnSuccess, that is true by default.  Setting it to false causes the plugin to disregard the status and proceed.

I did not add any specific tests for the new functionality.  If you would like me to do so before accepting, would you mind giving me a little guidance on what you would like to see?  I ask mostly because I see both a backwards compatible section, and also a regular section.

Note I did add a backwards compatible constructor.

I have tested this in production locally, both with the flag set true, false, and not set at all.  What I have -not- tested currently is making use of it in the GUI.  (I only use it via Jenkinsfile currently)

