### PR TITLE
JENKINS-54537 - Rename property tags to tagList

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .classpath
 .project
 .settings
+.factorypath
 target
 work
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## Change Log
 
+#### Version 3.6.10 (tba)
+
+-   [JENKINS-54537](https://issues.jenkins.io/browse/JENKINS-54537)
+    Renamed property tags in RundeckNotifier to tagsList to resolve a conflict
+    between XStream and the Jenkins-Struct-Plugin (String-Array vs String)
+
 #### Version 3.6.1 (Jan 26, 2017)
 
 -   [JENKINS-34510](https://issues.jenkins-ci.org/browse/JENKINS-34510)

--- a/src/test/java/org/jenkinsci/plugins/rundeck/RundeckNotifierBackwardCompatibilityTest.java
+++ b/src/test/java/org/jenkinsci/plugins/rundeck/RundeckNotifierBackwardCompatibilityTest.java
@@ -151,7 +151,8 @@ public class RundeckNotifierBackwardCompatibilityTest extends HudsonTestCase {
         assertEquals("Default", notifier.getRundeckInstance());
         assertEquals("ded72a13-8d82-48be-bec9-08a3870d5210", notifier.getJobId());
         assertEquals("test", notifier.getTag());
-        assertTrue(Arrays.equals(new String[] {"test"}, notifier.getTags()));
+        assertEquals("test", notifier.getTags());
+        assertTrue(Arrays.equals(new String[] {"test"}, notifier.getTagsList()));
     }
 
     @LocalData

--- a/src/test/java/org/jenkinsci/plugins/rundeck/RundeckNotifierTest.java
+++ b/src/test/java/org/jenkinsci/plugins/rundeck/RundeckNotifierTest.java
@@ -344,23 +344,23 @@ public class RundeckNotifierTest extends HudsonTestCase {
 
         notifier = new RundeckNotifier("Default", "1", null, null, "#deploy", false, true, null, null, null);
         tags= new String[] {"#deploy"};
-        assertTrue(Arrays.equals(tags, notifier.getTags()));
+        assertTrue(Arrays.equals(tags, notifier.getTagsList()));
 
         notifier = new RundeckNotifier("Default", "1", null, null, null, false, true, null, null, null);
         tags= new String[0];
-        assertTrue(Arrays.equals(tags, notifier.getTags()));
+        assertTrue(Arrays.equals(tags, notifier.getTagsList()));
 
         notifier = new RundeckNotifier("Default", "1", null, null, "", false, true, null, null, null);
         tags= new String[0];
-        assertTrue(Arrays.equals(tags, notifier.getTags()));
+        assertTrue(Arrays.equals(tags, notifier.getTagsList()));
 
         notifier = new RundeckNotifier("Default", "1", null, null, "  ", false, true, null, null, null);
         tags= new String[0];
-        assertTrue(Arrays.equals(tags, notifier.getTags()));
+        assertTrue(Arrays.equals(tags, notifier.getTagsList()));
 
         notifier = new RundeckNotifier("Default", "1", null, null, "#tag1, #tag2", false, true, null, null, null);
         tags= new String[] {"#tag1", "#tag2"};
-        assertTrue(Arrays.equals(tags, notifier.getTags()));
+        assertTrue(Arrays.equals(tags, notifier.getTagsList()));
 
     }
 


### PR DESCRIPTION
 Fixes JENKINS-54537 by renaming the property tags to tagsList inside Class RundeckNotifier. The solution keeps 
 the backward compatibility by using the XStreamAlias-Annotation. 

 This fix may have an impact on JENKINS-64706. We could not reproduce this issue anymore. 

 By the way this solution reduces the size of our Jenkins-log massively, because the stacktrace messed it up.
