### PR TITLE
[JENKINS-66307] Prepare Rundeck for core Guava upgrade

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>4.4</version>
+        <version>4.24</version>
         <relativePath />
     </parent>
 
@@ -88,9 +88,15 @@
             <dependency>
                 <groupId>io.jenkins.tools.bom</groupId>
                 <artifactId>bom-2.222.x</artifactId>
-                <version>10</version>
+                <version>887.vae9c8ac09ff7</version>
                 <scope>import</scope>
                 <type>pom</type>
+            </dependency>
+            <!-- Upper bounds between JTH and Xalan serializer which contains older version -->
+            <dependency>
+                <groupId>xml-apis</groupId>
+                <artifactId>xml-apis</artifactId>
+                <version>1.4.01</version>
             </dependency>
         </dependencies>
     </dependencyManagement>
@@ -121,20 +127,13 @@
             <version>2.7.2</version>
         </dependency>
         <dependency>
-            <!-- Upper bounds between JTH and Xalan serializer which contains older version -->
-            <groupId>xml-apis</groupId>
-            <artifactId>xml-apis</artifactId>
-            <version>1.4.01</version>
-        </dependency>
-        <dependency>
             <groupId>commons-lang</groupId>
             <artifactId>commons-lang</artifactId>
             <version>2.6</version>
         </dependency>
         <dependency>
-            <groupId>com.google.guava</groupId>
-            <artifactId>guava</artifactId>
-            <version>11.0.1</version>
+            <groupId>io.jenkins.plugins</groupId>
+            <artifactId>caffeine-api</artifactId>
         </dependency>
         <dependency>
             <groupId>org.jmockit</groupId>
@@ -145,13 +144,11 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>subversion</artifactId>
-            <version>2.8</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>ssh-credentials</artifactId>
-            <version>1.11</version>
             <scope>test</scope>
         </dependency>
         <!-- https://mvnrepository.com/artifact/org.codehaus.groovy/groovy-all -->
@@ -207,7 +204,6 @@
             <plugin>
                 <groupId>org.codehaus.gmavenplus</groupId>
                 <artifactId>gmavenplus-plugin</artifactId>
-                <version>1.10.0</version>
                 <executions>
                     <execution>
                         <!-- Without joint compilation - no dependencies between Java and Groovy (inheritance)-->
@@ -230,7 +226,6 @@
             <plugin>
                 <groupId>org.jenkins-ci.tools</groupId>
                 <artifactId>maven-hpi-plugin</artifactId>
-                <version>3.5</version>
                 <extensions>true</extensions>
                 <configuration>
                     <minimumJavaVersion />
@@ -247,7 +242,6 @@
             </plugin>
             <plugin>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.19</version>
                 <configuration>
                     <testSourceDirectory>src/test/groovy</testSourceDirectory>
                     <testSourceDirectory>src/test/java</testSourceDirectory>
@@ -263,7 +257,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-deploy-plugin</artifactId>
-                <version>2.6</version>
                 <dependencies>
                     <dependency>
                         <groupId>org.apache.maven.wagon</groupId>

--- a/src/main/java/org/jenkinsci/plugins/rundeck/cache/InMemoryRundeckJobCache.java
+++ b/src/main/java/org/jenkinsci/plugins/rundeck/cache/InMemoryRundeckJobCache.java
@@ -39,7 +39,7 @@ public class InMemoryRundeckJobCache implements RundeckJobCache {
     public InMemoryRundeckJobCache(final RundeckJobCacheConfig rundeckJobCacheConfig) {
         Objects.requireNonNull(rundeckJobCacheConfig);
         this.cacheStatsDisplayHitThreshold = rundeckJobCacheConfig.getCacheStatsDisplayHitThreshold();
-        this.rundeckJobInstanceAwareCache = Caffeine.newBuilder()
+        this.rundeckJobInstanceAwareCache = Caffeine.newBuilder().recordStats()
                 .expireAfterAccess(RUNDECK_INSTANCE_CACHE_CONTAINER_EXPIRATION_IN_DAYS, TimeUnit.DAYS)    //just in case given instance was removed
                 .build(
                         rundeckInstanceName -> createJobCacheForRundeckInstance(rundeckInstanceName, rundeckJobCacheConfig));
@@ -47,7 +47,7 @@ public class InMemoryRundeckJobCache implements RundeckJobCache {
 
     private Cache<String, JobItem> createJobCacheForRundeckInstance(String rundeckInstanceName, RundeckJobCacheConfig rundeckJobCacheConfig) {
         log.info(format("Loading (GENERATING) jobs cache container for Rundeck instance %s", rundeckInstanceName));
-        return Caffeine.newBuilder()
+        return Caffeine.newBuilder().recordStats()
                 .expireAfterAccess(rundeckJobCacheConfig.getAfterAccessExpirationInMinutes(), TimeUnit.MINUTES)
                 .maximumSize(rundeckJobCacheConfig.getMaximumSize())
                 .build();


### PR DESCRIPTION
See [JENKINS-65988](https://issues.jenkins.io/browse/JENKINS-65988) and [JENKINS-66307](https://issues.jenkins.io/browse/JENKINS-66307). Jenkins core is using [Guava 11.0.1](https://github.com/google/guava/releases/tag/v11.0.1), which was released on January 9, 2012. Jenkins core would like to upgrade to [Guava 30.1.1](https://github.com/google/guava/releases/tag/v30.1.1), which was released on March 19, 2021. Plugins must be prepared to be compatible with both Guava 11.0.1 and Guava 30.1.1 in advance of this core transition.

In particular, this plugin has been identified as using the `com.google.common.cache.Cache` API, which has been removed between Guava [11.0.1](https://guava.dev/releases/11.0.1/api/docs/com/google/common/cache/Cache.html) and [latest](https://guava.dev/releases/snapshot-jre/api/docs/com/google/common/cache/Cache.html). The removal took place in Guava 12.0.

To facilitate the Jenkins core transition, this plugin must be prepared and released such that it works with both Guava 11.0.1 and latest. The recommendation is for plugins to migrate from Guava's cache to [Caffeine](https://github.com/ben-manes/caffeine) via the Jenkins [Caffeine API](https://plugins.jenkins.io/caffeine-api/) plugin. This PR removes all usages of Guava and replaces them with Caffeine. This allows the plugin to be used with both the old and new versions of Guava.