### PR TITLE
RSE-29: Enh: Rundeck plugin in Jenkins not accepting URL on self signed SSL

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/rundeck/RundeckInstanceBuilder.java
+++ b/src/main/java/org/jenkinsci/plugins/rundeck/RundeckInstanceBuilder.java
@@ -11,6 +11,7 @@ public class RundeckInstanceBuilder {
     private Secret token;
     private Secret password;
     RundeckManager client;
+    private boolean allowSelfSignedSSL;
 
     public RundeckInstanceBuilder() {
     }
@@ -76,6 +77,11 @@ public class RundeckInstanceBuilder {
         return this;
     }
 
+    RundeckInstanceBuilder allowSelfSignedSSL(boolean allowSelfSignedSSL){
+        this.allowSelfSignedSSL = allowSelfSignedSSL;
+        return this;
+    }
+
     public RundeckInstance build() {
         RundeckInstance client = new RundeckInstance();
         client.setUrl(this.url);
@@ -83,6 +89,7 @@ public class RundeckInstanceBuilder {
         client.setLogin(this.login);
         client.setPassword(this.password);
         client.setToken(this.token);
+        client.setSslCertificateTrustAllowSelfSigned(this.allowSelfSignedSSL);
 
         return client;
     }

--- a/src/main/resources/org/jenkinsci/plugins/rundeck/RundeckNotifier/global.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/rundeck/RundeckNotifier/global.jelly
@@ -12,7 +12,7 @@
               </f:block>
           </r:blockWrapper>
       </f:entry>
-      <f:entry title="SSL">
+      <f:entry title="SSL" description="This should be used for testing ONLY.">
           <f:checkbox field="allowSelfSignedSSL" title="Allow self signed certificates." />
       </f:entry>
       <f:entry title="Instances" description="List of Rundeck instances">

--- a/src/main/resources/org/jenkinsci/plugins/rundeck/RundeckNotifier/global.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/rundeck/RundeckNotifier/global.jelly
@@ -2,17 +2,20 @@
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout"
          xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:r="/lib/rundeck">
   <f:section title="Rundeck">
-    <f:entry title="Job cache" description="Rundeck job cache configuration">
-      <r:blockWrapper>
-        <f:block>
-          <f:optionalBlock name="rundeckJobCacheEnabled" title="Enable Rundeck job cache" checked="${descriptor.rundeckJobCacheConfig.enabled}">
-            <f:validateButton title="Cache statistics" method="displayCacheStatistics" with=""/>
-            <f:validateButton title="Invalidate cache" method="invalidateCache" with=""/>
-          </f:optionalBlock>
-        </f:block>
-      </r:blockWrapper>
-    </f:entry>
-    <f:entry title="Instances" description="List of Rundeck instances">
+      <f:entry title="Job cache" description="Rundeck job cache configuration">
+          <r:blockWrapper>
+              <f:block>
+                  <f:optionalBlock name="rundeckJobCacheEnabled" title="Enable Rundeck job cache" checked="${descriptor.rundeckJobCacheConfig.enabled}">
+                      <f:validateButton title="Cache statistics" method="displayCacheStatistics" with=""/>
+                      <f:validateButton title="Invalidate cache" method="invalidateCache" with=""/>
+                  </f:optionalBlock>
+              </f:block>
+          </r:blockWrapper>
+      </f:entry>
+      <f:entry title="SSL">
+          <f:checkbox field="allowSelfSignedSSL" title="Allow self signed certificates." />
+      </f:entry>
+      <f:entry title="Instances" description="List of Rundeck instances">
       <f:repeatable var="inst" items="${descriptor.rundeckInstances}" add="Add Rundeck">
         <r:blockWrapper>
             <f:entry title="Name">
@@ -34,7 +37,7 @@
               <f:textbox name="rundeck.apiversion" value="${descriptor.getApiVersion(inst.getValue())}" />
             </f:entry>
             <f:validateButton title="Test Connection" progress="Testing..." method="testConnection"
-              with="rundeck.url,rundeck.login,rundeck.password,rundeck.authtoken,rundeck.apiversion" />
+              with="rundeck.url,rundeck.login,rundeck.password,rundeck.authtoken,rundeck.apiversion,allowSelfSignedSSL" />
             <f:entry title="">
               <div align="right">
                 <f:repeatableDeleteButton value="Delete Rundeck"/>

--- a/src/test/java/org/jenkinsci/plugins/rundeck/RundeckNotifierBackwardCompatibilityTest.java
+++ b/src/test/java/org/jenkinsci/plugins/rundeck/RundeckNotifierBackwardCompatibilityTest.java
@@ -72,6 +72,7 @@ public class RundeckNotifierBackwardCompatibilityTest extends HudsonTestCase {
                 "      </org.jenkinsci.plugins.rundeck.RundeckInstance>\n" +
                 "    </entry>\n" +
                 "  </rundeckInstances>\n" +
+                "  <allowSelfSignedSSL>false</allowSelfSignedSSL>\n" +
                 "  <rundeckJobCacheConfig>\n" +
                 "    <enabled>false</enabled>\n" +
                 "    <afterAccessExpirationInMinutes>1080</afterAccessExpirationInMinutes>\n" +


### PR DESCRIPTION
Fix: https://pagerduty.atlassian.net/browse/RSE-29
Fix: https://github.com/rundeckpro/rundeckpro/issues/2664

#### Solution
Add a checkbox to let users allow/deny (deny by default) the usage of self signed certificates in all or none of their instances

![image](https://user-images.githubusercontent.com/49494423/185491234-8611e60f-13b8-402e-a642-f0f3af6952cb.png)


#### Problem
A customer reported that they can't setup a rundeck instance using a self signed ssl certificate:

Reproduced on RD 3.4.8 / 4.4.0 (with SSL enabled), Postgres / Mysql, Jenkins 2.360

Rundeck plugin in Jenkins not accepting SSL communication against RD.
![image](https://user-images.githubusercontent.com/49494423/185490337-67acbe9a-110c-4a08-be72-c3a16ef3237f.png)

This can be solved by downgrading RD to non SSL
![image](https://user-images.githubusercontent.com/49494423/185490378-9053f62b-224f-4c9c-861b-b2ada2ecaf49.png)