### PR TITLE
validate artifact ACL in OptionProvider

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -173,12 +173,43 @@
                 </exclusion>
             </exclusions>
         </dependency>
+        <!-- https://mvnrepository.com/artifact/cglib/cglib-nodep -->
+        <dependency>
+            <groupId>cglib</groupId>
+            <artifactId>cglib-nodep</artifactId>
+            <version>3.3.0</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>cglib</groupId>
+            <artifactId>cglib</artifactId>
+            <version>3.3.0</version>
+            <scope>test</scope>
+        </dependency>
+
+        <!-- https://mvnrepository.com/artifact/org.objenesis/objenesis -->
+        <dependency>
+            <groupId>org.objenesis</groupId>
+            <artifactId>objenesis</artifactId>
+            <version>3.3</version>
+            <scope>test</scope>
+        </dependency>
+
         <dependency>
             <groupId>org.spockframework</groupId>
             <artifactId>spock-core</artifactId>
             <version>1.3-groovy-2.5</version>
             <scope>test</scope>
         </dependency>
+
+        <dependency>
+            <groupId>com.homeaway.devtools.jenkins</groupId>
+            <artifactId>jenkins-spock</artifactId>
+            <scope>test</scope>
+            <version>2.1.5</version>
+        </dependency>
+
         <dependency>
             <groupId>com.google.code.gson</groupId>
             <artifactId>gson</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -204,13 +204,6 @@
         </dependency>
 
         <dependency>
-            <groupId>com.homeaway.devtools.jenkins</groupId>
-            <artifactId>jenkins-spock</artifactId>
-            <scope>test</scope>
-            <version>2.1.5</version>
-        </dependency>
-
-        <dependency>
             <groupId>com.google.code.gson</groupId>
             <artifactId>gson</artifactId>
             <version>2.9.0</version>

--- a/src/test/groovy/jenkinsci/plugins/rundeck/OptionProviderSpec.groovy
+++ b/src/test/groovy/jenkinsci/plugins/rundeck/OptionProviderSpec.groovy
@@ -1,0 +1,158 @@
+package jenkinsci.plugins.rundeck
+
+import hudson.model.FreeStyleBuild
+import hudson.model.Hudson
+import hudson.model.Job
+import hudson.model.Run
+import hudson.security.AccessDeniedException2
+import hudson.util.RunList
+import jenkins.model.Jenkins
+import org.jenkinsci.plugins.rundeck.OptionProvider
+import org.kohsuke.stapler.StaplerRequest
+import org.kohsuke.stapler.StaplerResponse
+import spock.lang.Specification
+
+import javax.servlet.http.HttpServletResponse
+
+import static hudson.model.Run.ARTIFACTS
+
+class OptionProviderSpec extends Specification {
+
+
+    def "test option artifact without permissions"(){
+
+        given:
+
+        final Hudson jenkins = Mock()
+
+        jenkins.getInstanceOrNull() >> jenkins
+        jenkins.getInstance() >> jenkins
+
+        Jenkins.HOLDER = new Jenkins.JenkinsHolder() {
+            Jenkins getInstance() {
+                return jenkins
+            }
+        }
+
+        jenkins.getItemByFullName("test", _)>>Mock(Job) {
+            getLastSuccessfulBuild() >> Mock(FreeStyleBuild) {
+                checkPermission(ARTIFACTS) >> { throw new AccessDeniedException2(Jenkins.getAuthentication(), ARTIFACTS) }
+            }
+        }
+
+        def response = Mock(StaplerResponse)
+
+        when:
+        OptionProvider optionProvider = new OptionProvider()
+        def request = Mock(StaplerRequest){
+            getParameter("project")>>"test"
+            getParameter("build")>>"lastSuccessful"
+        }
+        def result = optionProvider.doArtifact(request,response )
+
+        then:
+        1 * response.sendError(HttpServletResponse.SC_BAD_REQUEST, {message-> message == "anonymous is missing the Run/Artifacts permission" });
+
+    }
+
+    def "test option artifact with permissions"(){
+
+        given:
+
+        final Hudson jenkins = Mock(){
+            getRootUrl()>>"http://localhost:8080"
+        }
+
+        jenkins.getInstanceOrNull() >> jenkins
+        jenkins.getInstance() >> jenkins
+
+        Jenkins.HOLDER = new Jenkins.JenkinsHolder() {
+            Jenkins getInstance() {
+                return jenkins
+            }
+        }
+
+        jenkins.getItemByFullName("test", _)>>Mock(Job) {
+            getLastSuccessfulBuild() >> Mock(FreeStyleBuild) {
+                getArtifacts()>> [
+                        Mock(Run.Artifact){
+                            getFileName()>>"test-1.0.jar"
+                            getHref()>>"artifact/test-1.0.jar"
+                        }
+                ]
+                getUrl()>>"/rundeck/"
+            }
+        }
+
+        def writer = Mock(PrintWriter)
+        def response = Mock(StaplerResponse){
+            getWriter()>>writer
+        }
+
+        when:
+        OptionProvider optionProvider = new OptionProvider()
+        def request = Mock(StaplerRequest){
+            getParameter("project")>>"test"
+            getParameter("build")>>"lastSuccessful"
+        }
+        optionProvider.doArtifact(request,response )
+
+        then:
+        1*writer.append({json-> json == "[{\"name\":\"test-1.0.jar\",\"value\":\"http://localhost:8080/rundeck/artifact/artifact/test-1.0.jar\"}]"})
+
+    }
+
+    def "test option build without permissions"(){
+
+        given:
+
+        final Hudson jenkins = Mock()
+
+        jenkins.getInstanceOrNull() >> jenkins
+        jenkins.getInstance() >> jenkins
+
+        Jenkins.HOLDER = new Jenkins.JenkinsHolder() {
+            Jenkins getInstance() {
+                return jenkins
+            }
+        }
+
+        List builds = [
+                Mock(FreeStyleBuild) {
+                    getArtifacts()>> [
+                            Mock(Run.Artifact){
+                                getFileName()>>"test-1.0.jar"
+                                getHref()>>"artifact/test-1.0.jar"
+                            }
+                    ]
+                    getUrl()>>"/rundeck/"
+                    checkPermission(ARTIFACTS) >> { throw new AccessDeniedException2(Jenkins.getAuthentication(), ARTIFACTS) }
+
+                }
+        ]
+
+        jenkins.getItemByFullName("test", _)>>Mock(Job) {
+            getBuilds()>> Mock(RunList){
+                iterator()>>builds.iterator()
+            }
+        }
+
+        def writer = Mock(PrintWriter)
+        def response = Mock(StaplerResponse){
+            getWriter()>>writer
+        }
+
+        when:
+        OptionProvider optionProvider = new OptionProvider()
+        def request = Mock(StaplerRequest){
+            getParameter("project")>>"test"
+            getParameter("artifactRegex")>>".jar"
+            getParameter("build")>>"lastSuccessful"
+        }
+        def result = optionProvider.doBuild(request,response )
+
+        then:
+        1*writer.append({json-> json == "[]"})
+
+    }
+}

--- a/src/test/groovy/jenkinsci/plugins/rundeck/OptionProviderSpec.groovy
+++ b/src/test/groovy/jenkinsci/plugins/rundeck/OptionProviderSpec.groovy
@@ -22,6 +22,7 @@ class OptionProviderSpec extends Specification {
 
     def setup() {
          originalHolder = Jenkins.HOLDER
+        System.properties['hudson.security.ArtifactsPermission'] = "true"
     }
 
     def cleanup() {

--- a/src/test/groovy/jenkinsci/plugins/rundeck/OptionProviderSpec.groovy
+++ b/src/test/groovy/jenkinsci/plugins/rundeck/OptionProviderSpec.groovy
@@ -18,15 +18,25 @@ import static hudson.model.Run.ARTIFACTS
 
 class OptionProviderSpec extends Specification {
 
+    def originalHolder
+
+    def setup() {
+         originalHolder = Jenkins.HOLDER
+    }
+
+    def cleanup() {
+        Jenkins.HOLDER = originalHolder
+    }
 
     def "test option artifact without permissions"(){
 
         given:
 
         final Hudson jenkins = Mock()
-
         jenkins.getInstanceOrNull() >> jenkins
         jenkins.getInstance() >> jenkins
+
+        def originalHolder = Jenkins.HOLDER
 
         Jenkins.HOLDER = new Jenkins.JenkinsHolder() {
             Jenkins getInstance() {
@@ -48,10 +58,12 @@ class OptionProviderSpec extends Specification {
             getParameter("project")>>"test"
             getParameter("build")>>"lastSuccessful"
         }
-        def result = optionProvider.doArtifact(request,response )
+
+        optionProvider.doArtifact(request,response )
 
         then:
         1 * response.sendError(HttpServletResponse.SC_BAD_REQUEST, {message-> message == "anonymous is missing the Run/Artifacts permission" });
+
 
     }
 
@@ -155,4 +167,5 @@ class OptionProviderSpec extends Specification {
         1*writer.append({json-> json == "[]"})
 
     }
+
 }


### PR DESCRIPTION

<!-- Please describe your pull request here. -->

- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- [] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [X] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->

- Add ARTIFACTS permission checks for `option/artifact` endpoint and `option/build`
- in the case of `option/artifact` returns a bad request if the permission is not set
- in the case of `option/build` the build that doesn't have permissions won't be added in the returner Rundeck option list

