### PR TITLE
[JENKINS-70122]: print tailing exception using logging

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/rundeck/RunDeckLogTail.java
+++ b/src/main/java/org/jenkinsci/plugins/rundeck/RunDeckLogTail.java
@@ -117,7 +117,8 @@ public class RunDeckLogTail implements Iterable<List<ExecLog>> {
                             maxRetries, e });
                     sleepOrThrowException(e);
                 } catch (IOException e) {
-                    e.printStackTrace();
+                    log.log(Level.SEVERE, "Rundeck Exception:", e);
+                    //e.printStackTrace();
                 }
             } catch (InterruptedException e) {
                 log.warning("Caught InterruptedException, will set completed to 'true'.");


### PR DESCRIPTION
<!-- Please describe your pull request here. -->
When rundeck is slow, we see this exception being printed many many times in Jenkins log but the thing is there is rarely any issue notices in jenkins build log and its because the next iteration for tailing generally resolves such intermittent failures, because its non-blocking in nature, we should print this exception using logging framework, so that we can stop jenkins logs being clogged with these exceptions which then inhibits debugging other more imp issues.

- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
