### PR TITLE
Handle dorment login configuration in RundeckClientManager

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -142,6 +142,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>subversion</artifactId>
             <scope>test</scope>

--- a/src/main/java/org/jenkinsci/plugins/rundeck/client/RundeckClientManager.java
+++ b/src/main/java/org/jenkinsci/plugins/rundeck/client/RundeckClientManager.java
@@ -1,9 +1,11 @@
 package org.jenkinsci.plugins.rundeck.client;
 
+import com.google.common.annotations.VisibleForTesting;
 import hudson.AbortException;
 import okhttp3.ResponseBody;
 import org.jenkinsci.plugins.rundeck.RundeckInstance;
 import org.rundeck.client.RundeckClient;
+import org.rundeck.client.RundeckClient.Builder;
 import org.rundeck.client.api.RundeckApi;
 import org.rundeck.client.api.model.*;
 import org.rundeck.client.api.model.scheduler.ScheduledJobItem;
@@ -23,12 +25,28 @@ public class RundeckClientManager implements RundeckManager {
     private RundeckInstance rundeckInstance;
     private Client<RundeckApi> client;
 
+    private Builder<RundeckApi> clientBuilder;
+
     public RundeckClientManager() {
     }
 
     public RundeckClientManager(RundeckInstance rundeckInstance) {
         this.rundeckInstance = rundeckInstance;
         buildClient();
+    }
+
+
+    private Builder<RundeckApi> createRundeckClientBuilder() {
+        if (clientBuilder != null) {
+            return clientBuilder;
+        } else {
+            return RundeckClient.builder();
+        }
+    }
+
+    @VisibleForTesting
+    protected void setRundeckClientBuilder(Builder<RundeckApi> builder) {
+        clientBuilder = builder;
     }
 
     public RundeckInstance getRundeckInstance() {
@@ -49,12 +67,13 @@ public class RundeckClientManager implements RundeckManager {
 
     public void buildClient(){
         if(client == null){
-            RundeckClient.Builder builder = RundeckClient.builder().baseUrl(rundeckInstance.getUrl());
+            RundeckClient.Builder builder = createRundeckClientBuilder().baseUrl(rundeckInstance.getUrl());
 
             if(rundeckInstance.getToken()!=null && !rundeckInstance.getToken().getPlainText().isEmpty()){
                 builder.tokenAuth(rundeckInstance.getToken().getPlainText());
             }
-            if(rundeckInstance.getLogin() != null && rundeckInstance.getPassword()!=null){
+            if (rundeckInstance.getLogin() != null && rundeckInstance.getPassword() != null
+                && !rundeckInstance.getPassword().getPlainText().isEmpty()) {
                 builder.passwordAuth(rundeckInstance.getLogin(),rundeckInstance.getPassword().getPlainText() );
             }
 

--- a/src/test/java/org/jenkinsci/plugins/rundeck/client/RundeckClientManagerTest.java
+++ b/src/test/java/org/jenkinsci/plugins/rundeck/client/RundeckClientManagerTest.java
@@ -1,0 +1,39 @@
+package org.jenkinsci.plugins.rundeck.client;
+
+import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import hudson.util.Secret;
+import org.jenkinsci.plugins.rundeck.RundeckInstance;
+import org.junit.Test;
+import org.rundeck.client.RundeckClient;
+import org.rundeck.client.RundeckClient.Builder;
+import org.rundeck.client.api.RundeckApi;
+
+public class RundeckClientManagerTest {
+
+    @Test
+    public void usingTokenDoesNotTryToSetUsernameAndPasswordCredentialsMethodWhenEarlierLoginInformationIsFoundInConfiguration() {
+
+        Builder<RundeckApi> clientBuilderSpy = spy(RundeckClient.builder());
+
+        RundeckInstance rundeckInstanceMock = mock(RundeckInstance.class);
+        when(rundeckInstanceMock.getUrl()).thenReturn("http://localhost:4044");
+
+        when(rundeckInstanceMock.getToken()).thenReturn(Secret.fromString("aToken"));
+        when(rundeckInstanceMock.getTokenPlainText()).thenReturn("aToken");
+        when(rundeckInstanceMock.getLogin()).thenReturn("bad_data_from_plugin_data_somehow");
+        when(rundeckInstanceMock.getPassword()).thenReturn(Secret.fromString(""));
+        when(rundeckInstanceMock.getPasswordPlainText()).thenReturn("");
+
+        RundeckClientManager rundeckClientManager = new RundeckClientManager(rundeckInstanceMock);
+        rundeckClientManager.setRundeckClientBuilder(clientBuilderSpy);
+        rundeckClientManager.buildClient();
+
+        verify(clientBuilderSpy, never()).passwordAuth(anyString(), anyString());
+
+    }
+}


### PR DESCRIPTION
Validate both username and password has value before trying to use passwordAuth.

An empty string leaves a valid Secret type, and login information seems
to stay from earlier plugin versions and has not been removed by the
plugin-upgrade-process. (That's my assumption)

- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [X] Ensure you have provided tests - that demonstrates feature works or fixes the issue